### PR TITLE
New array assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `$assert->array()->contains()`
+- `$assert->array()->not()->contains()`
+
 ## 5.7.0 - 2024-07-21
 
 ### Added

--- a/documentation/assert/primitives.md
+++ b/documentation/assert/primitives.md
@@ -230,22 +230,6 @@ static function(Assert $assert) {
     }
     ```
 
-=== "Count"
-    ```php
-    static function(Assert $assert) {
-        $assert->count($count, $array, 'Optional error message');
-    }
-    ```
-
-=== "Doesn't have count"
-    ```php
-    static function(Assert $assert) {
-        $assert
-            ->not()
-            ->count($count, $array, 'Optional error message');
-    }
-    ```
-
 === "Contains a value"
     ```php
     static function(Assert $assert) {
@@ -262,5 +246,21 @@ static function(Assert $assert) {
             ->array($array)
             ->not()
             ->contains($value, 'Optional error message');
+    }
+    ```
+
+=== "Count"
+    ```php
+    static function(Assert $assert) {
+        $assert->count($count, $array, 'Optional error message');
+    }
+    ```
+
+=== "Doesn't have count"
+    ```php
+    static function(Assert $assert) {
+        $assert
+            ->not()
+            ->count($count, $array, 'Optional error message');
     }
     ```

--- a/documentation/assert/primitives.md
+++ b/documentation/assert/primitives.md
@@ -250,8 +250,8 @@ static function(Assert $assert) {
     ```php
     static function(Assert $assert) {
         $assert
-            ->expected($someValue)
-            ->in($iterable, 'Optional error message');
+            ->array($array)
+            ->contains($value, 'Optional error message');
     }
     ```
 
@@ -259,8 +259,8 @@ static function(Assert $assert) {
     ```php
     static function(Assert $assert) {
         $assert
-            ->expected($someValue)
+            ->array($array)
             ->not()
-            ->in($iterable, 'Optional error message');
+            ->contains($value, 'Optional error message');
     }
     ```

--- a/proofs/runner/assert.php
+++ b/proofs/runner/assert.php
@@ -1319,6 +1319,82 @@ return static function($load) {
     )->tag(Tag::ci, Tag::local);
 
     yield proof(
+        'Assert->array()->contains()',
+        given(
+            Set\Type::any(),
+            Set\Sequence::of(Set\Type::any()),
+            Set\Sequence::of(Set\Type::any()),
+            Set\Strings::any(),
+        )->filter(
+            static fn($expected, $prefix, $suffix) => !\in_array($expected, $prefix, true) &&
+                !\in_array($expected, $suffix, true),
+        ),
+        static function($assert, $expected, $prefix, $suffix, $message) {
+            $sut = Assert::of($stats = Stats::new());
+
+            $array = [...$prefix, ...[$expected], ...$suffix];
+
+            $sut->array($array)->contains($expected);
+
+            try {
+                $sut->array([...$prefix, ...$suffix])->contains($expected);
+                $assert->fail($message);
+            } catch (Failure $e) {
+                $assert
+                    ->expected($message)
+                    ->not()
+                    ->same($e->kind()->message());
+                $assert->same(
+                    'Failed to assert an array contains a value',
+                    $e->kind()->message(),
+                );
+            }
+
+            $assert
+                ->expected(4)
+                ->same($stats->assertions());
+        },
+    )->tag(Tag::ci, Tag::local);
+
+    yield proof(
+        'Assert->array()->not()->contains()',
+        given(
+            Set\Type::any(),
+            Set\Sequence::of(Set\Type::any()),
+            Set\Sequence::of(Set\Type::any()),
+            Set\Strings::any(),
+        )->filter(
+            static fn($expected, $prefix, $suffix) => !\in_array($expected, $prefix, true) &&
+                !\in_array($expected, $suffix, true),
+        ),
+        static function($assert, $expected, $prefix, $suffix, $message) {
+            $sut = Assert::of($stats = Stats::new());
+
+            $array = [...$prefix, ...[$expected], ...$suffix];
+
+            $sut->array([...$prefix, ...$suffix])->not()->contains($expected);
+
+            try {
+                $sut->array($array)->not()->contains($expected);
+                $assert->fail($message);
+            } catch (Failure $e) {
+                $assert
+                    ->expected($message)
+                    ->not()
+                    ->same($e->kind()->message());
+                $assert->same(
+                    'Failed to assert an array does not contain a value',
+                    $e->kind()->message(),
+                );
+            }
+
+            $assert
+                ->expected(4)
+                ->same($stats->assertions());
+        },
+    )->tag(Tag::ci, Tag::local);
+
+    yield proof(
         'Assert->matches()',
         given(
             Set\Type::any(),

--- a/src/Runner/Assert/Arr.php
+++ b/src/Runner/Assert/Arr.php
@@ -6,6 +6,7 @@ namespace Innmind\BlackBox\Runner\Assert;
 use Innmind\BlackBox\Runner\{
     Stats,
     Assert\Failure\Property,
+    Assert\Failure\Comparison,
 };
 
 final class Arr
@@ -49,6 +50,26 @@ final class Arr
                     'Failed to assert an array has the key "%s"',
                     $key,
                 ),
+            ));
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param non-empty-string $message
+     *
+     * @throws Failure
+     */
+    public function contains(mixed $value, string $message = null): self
+    {
+        $this->stats->incrementAssertions();
+
+        if (!\in_array($value, $this->value, true)) {
+            throw Failure::of(Comparison::of(
+                $value,
+                $this->value,
+                $message ?? 'Failed to assert an array contains a value',
             ));
         }
 

--- a/src/Runner/Assert/Arr/Not.php
+++ b/src/Runner/Assert/Arr/Not.php
@@ -7,6 +7,7 @@ use Innmind\BlackBox\Runner\{
     Stats,
     Assert\Failure,
     Assert\Failure\Property,
+    Assert\Failure\Comparison,
 };
 
 final class Not
@@ -45,6 +46,26 @@ final class Not
                     'Failed to assert an array does not have the key "%s"',
                     $key,
                 ),
+            ));
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param non-empty-string $message
+     *
+     * @throws Failure
+     */
+    public function contains(mixed $value, string $message = null): self
+    {
+        $this->stats->incrementAssertions();
+
+        if (\in_array($value, $this->value, true)) {
+            throw Failure::of(Comparison::of(
+                $value,
+                $this->value,
+                $message ?? 'Failed to assert an array does not contain a value',
             ));
         }
 

--- a/tests/Set/IntegersTest.php
+++ b/tests/Set/IntegersTest.php
@@ -241,8 +241,13 @@ class IntegersTest extends TestCase
 
         do {
             $this->assertNotSame($previous->unwrap(), $integer->unwrap());
+
+            if (!$integer->shrinkable()) {
+                return;
+            }
+
             $previous = $integer;
-            $integer = $integer->shrink()?->b();
+            $integer = $integer->shrink()->b();
         } while ($integer?->shrinkable() ?? false);
     }
 


### PR DESCRIPTION
## Problem

To check if an array has a key the notation is `$assert->array()->hasKey()` but to check if it contains a value it's `$assert->expected()->in()`.

This is not optimal as the naming is completely different and it prevents chaining to check if multiple values are contained in an array.

## Solution

Add `$assert->array()->contains()` and `$assert->array()->not()->contains()`.