### PR TITLE
Add GitHub action printer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- By default the printer groups the proofs output in a GitHub Action
+- `Innmind\BlackBox\Runner\Printer\Standard::disableGitHubOutput()`
+
 ## 5.8.0 - 2024-11-09
 
 ### Added

--- a/documentation/config.md
+++ b/documentation/config.md
@@ -92,3 +92,22 @@ Application::new([])
     ->tryToProve(Load::everythingIn('proofs/'))
     ->exit();
 ```
+
+## Disable GitHub Action output
+
+When it detects it's run inside a GitHub Action the framework groups each proof output to make the output more compact for large suites. It also adds annotations to quickly jump to each failing proof.
+
+You can disable such behaviour like this:
+
+```php hl_lines="4 8"
+use Innmind\BlackBox\{
+    Application,
+    Runner\Load,
+    Runner\Printer\Standard,
+};
+
+Application::new([])
+    ->usePrinter(Standard::new()->disableGitHubOutput())
+    ->tryToProve(Load::everythingIn('proofs/'))
+    ->exit();
+```

--- a/proofs/application.php
+++ b/proofs/application.php
@@ -12,6 +12,11 @@ use Innmind\BlackBox\{
 };
 
 return static function() {
+    yield test(
+        'Failing on purpose',
+        static fn($assert) => $assert->true(false),
+    );
+
     yield proof(
         'BlackBox can run with any of the random strategies',
         given(Set\Elements::of(...Random::cases())),

--- a/proofs/application.php
+++ b/proofs/application.php
@@ -16,7 +16,6 @@ return static function() {
         'Failing on purpose',
         static fn($assert) => $assert->true(false),
     );
-    var_dump(getenv());
 
     yield proof(
         'BlackBox can run with any of the random strategies',

--- a/proofs/application.php
+++ b/proofs/application.php
@@ -12,11 +12,6 @@ use Innmind\BlackBox\{
 };
 
 return static function() {
-    yield test(
-        'Failing on purpose',
-        static fn($assert) => $assert->true(false),
-    )->tag(Tag::ci);
-
     yield proof(
         'BlackBox can run with any of the random strategies',
         given(Set\Elements::of(...Random::cases())),

--- a/proofs/application.php
+++ b/proofs/application.php
@@ -15,7 +15,7 @@ return static function() {
     yield test(
         'Failing on purpose',
         static fn($assert) => $assert->true(false),
-    );
+    )->tag(Tag::ci);
 
     yield proof(
         'BlackBox can run with any of the random strategies',

--- a/proofs/application.php
+++ b/proofs/application.php
@@ -16,6 +16,7 @@ return static function() {
         'Failing on purpose',
         static fn($assert) => $assert->true(false),
     );
+    var_dump(getenv());
 
     yield proof(
         'BlackBox can run with any of the random strategies',

--- a/proofs/runner/printer.php
+++ b/proofs/runner/printer.php
@@ -136,7 +136,7 @@ return static function() {
             Set\Sequence::of(Set\Elements::of(...Tag::cases())),
         ),
         static function($assert, $name, $tags) {
-            $printer = Standard::new()->disableGitHubGrouping();
+            $printer = Standard::new()->disableGitHubOutput();
             $io = Collect::new();
 
             $printer->proof($io, $io, Name::of($name), $tags);
@@ -189,7 +189,7 @@ return static function() {
             Set\Sequence::of(Set\Elements::of(...Tag::cases())),
         ),
         static function($assert, $name, $tags) {
-            $printer = Standard::new()->disableGitHubGrouping();
+            $printer = Standard::new()->disableGitHubOutput();
             $io = Collect::new();
 
             $printer
@@ -276,7 +276,7 @@ return static function() {
             Set\Strings::any(),
         ),
         static function($assert, $name, $val, $truth) {
-            $printer = Standard::new()->disableGitHubGrouping();
+            $printer = Standard::new()->disableGitHubOutput();
             $io = Collect::new();
 
             $printer
@@ -342,7 +342,7 @@ return static function() {
             Set\Strings::any(),
         ),
         static function($assert, $name, $property, $val, $message) {
-            $printer = Standard::new()->disableGitHubGrouping();
+            $printer = Standard::new()->disableGitHubOutput();
             $io = Collect::new();
 
             $printer
@@ -420,7 +420,7 @@ return static function() {
             Set\Strings::any(),
         ),
         static function($assert, $name, $expected, $actual, $val, $message) {
-            $printer = Standard::new()->disableGitHubGrouping();
+            $printer = Standard::new()->disableGitHubOutput();
             $io = Collect::new();
 
             $printer
@@ -566,7 +566,7 @@ return static function() {
             Set\Sequence::of(Set\Elements::of(...Tag::cases())),
         ),
         static function($assert, $name, $tags) {
-            $printer = Standard::new()->disableGitHubGrouping();
+            $printer = Standard::new()->disableGitHubOutput();
             $io = Collect::new();
 
             $printer

--- a/proofs/runner/printer.php
+++ b/proofs/runner/printer.php
@@ -136,7 +136,7 @@ return static function() {
             Set\Sequence::of(Set\Elements::of(...Tag::cases())),
         ),
         static function($assert, $name, $tags) {
-            $printer = Standard::new()->disableGitHubOutput();
+            $printer = Standard::new()->disableGitHubGrouping();
             $io = Collect::new();
 
             $printer->proof($io, $io, Name::of($name), $tags);
@@ -189,7 +189,7 @@ return static function() {
             Set\Sequence::of(Set\Elements::of(...Tag::cases())),
         ),
         static function($assert, $name, $tags) {
-            $printer = Standard::new()->disableGitHubOutput();
+            $printer = Standard::new()->disableGitHubGrouping();
             $io = Collect::new();
 
             $printer
@@ -448,7 +448,7 @@ return static function() {
             Set\Sequence::of(Set\Elements::of(...Tag::cases())),
         ),
         static function($assert, $name, $tags) {
-            $printer = Standard::new()->disableGitHubOutput();
+            $printer = Standard::new()->disableGitHubGrouping();
             $io = Collect::new();
 
             $printer

--- a/proofs/runner/printer.php
+++ b/proofs/runner/printer.php
@@ -136,7 +136,7 @@ return static function() {
             Set\Sequence::of(Set\Elements::of(...Tag::cases())),
         ),
         static function($assert, $name, $tags) {
-            $printer = Standard::new();
+            $printer = Standard::new()->disableGitHubOutput();
             $io = Collect::new();
 
             $printer->proof($io, $io, Name::of($name), $tags);
@@ -154,8 +154,58 @@ return static function() {
                 ->contains($name);
         },
     )->tag(Tag::ci, Tag::local);
+
+    yield proof(
+        'Printer->proof() in GitHub Action',
+        given(
+            Set\Strings::any(),
+            Set\Sequence::of(Set\Elements::of(...Tag::cases())),
+        ),
+        static function($assert, $name, $tags) {
+            $printer = Standard::new();
+            $io = Collect::new();
+
+            $printer->proof($io, $io, Name::of($name), $tags);
+
+            $written = $io->toString();
+
+            foreach ($tags as $tag) {
+                $assert
+                    ->string($written)
+                    ->contains($tag->name);
+            }
+
+            $assert
+                ->string($written)
+                ->startsWith('::group::')
+                ->contains($name);
+        },
+    )->tag(Tag::ci);
+
     yield proof(
         'Printer->proof()->emptySet()',
+        given(
+            Set\Strings::any(),
+            Set\Sequence::of(Set\Elements::of(...Tag::cases())),
+        ),
+        static function($assert, $name, $tags) {
+            $printer = Standard::new()->disableGitHubOutput();
+            $io = Collect::new();
+
+            $printer
+                ->proof($io, $io, Name::of($name), $tags)
+                ->emptySet($io, $io);
+
+            $written = $io->written();
+
+            $assert
+                ->expected("No scenario found\n")
+                ->same(\end($written));
+        },
+    )->tag(Tag::ci, Tag::local);
+
+    yield proof(
+        'Printer->proof()->emptySet() in GitHub Action',
         given(
             Set\Strings::any(),
             Set\Sequence::of(Set\Elements::of(...Tag::cases())),
@@ -171,10 +221,11 @@ return static function() {
             $written = $io->written();
 
             $assert
-                ->expected("No scenario found\n")
+                ->expected("No scenario found\n::endgroup::\n")
                 ->same(\end($written));
         },
-    )->tag(Tag::ci, Tag::local);
+    )->tag(Tag::ci);
+
     yield proof(
         'Printer->proof()->success()',
         given(
@@ -397,7 +448,7 @@ return static function() {
             Set\Sequence::of(Set\Elements::of(...Tag::cases())),
         ),
         static function($assert, $name, $tags) {
-            $printer = Standard::new();
+            $printer = Standard::new()->disableGitHubOutput();
             $io = Collect::new();
 
             $printer
@@ -408,6 +459,28 @@ return static function() {
 
             $assert
                 ->expected("\n\n")
+                ->same(\end($written));
+        },
+    )->tag(Tag::ci, Tag::local);
+
+    yield proof(
+        'Printer->proof()->end() in GitHub Action',
+        given(
+            Set\Strings::any(),
+            Set\Sequence::of(Set\Elements::of(...Tag::cases())),
+        ),
+        static function($assert, $name, $tags) {
+            $printer = Standard::new();
+            $io = Collect::new();
+
+            $printer
+                ->proof($io, $io, Name::of($name), $tags)
+                ->end($io, $io);
+
+            $written = $io->written();
+
+            $assert
+                ->expected("\n\n::endgroup::\n")
                 ->same(\end($written));
         },
     )->tag(Tag::ci, Tag::local);

--- a/proofs/runner/printer.php
+++ b/proofs/runner/printer.php
@@ -276,7 +276,7 @@ return static function() {
             Set\Strings::any(),
         ),
         static function($assert, $name, $val, $truth) {
-            $printer = Standard::new();
+            $printer = Standard::new()->disableGitHubGrouping();
             $io = Collect::new();
 
             $printer
@@ -299,8 +299,80 @@ return static function() {
                 ->contains($truth);
         },
     )->tag(Tag::ci, Tag::local);
+
+    yield proof(
+        'Printer->proof()->failure() for Failure\Truth in GitHub Action',
+        given(
+            Set\Strings::any(),
+            Set\Strings::madeOf(Set\Chars::alphanumerical()),
+            Set\Strings::any(),
+        ),
+        static function($assert, $name, $val, $truth) {
+            $printer = Standard::new();
+            $io = Collect::new();
+
+            $printer
+                ->proof($io, $io, Name::of($name), [])
+                ->failed($io, $io, Failure::of(
+                    Assert\Failure::of(Truth::of($truth)),
+                    Value::immutable(Scenario\Inline::of(
+                        [$val],
+                        static fn($assert, $foo) => null,
+                    )),
+                ));
+
+            $written = $io->toString();
+
+            $assert
+                ->string($written)
+                ->contains("F\n\n")
+                ->contains('$foo = ')
+                ->contains($val)
+                ->contains('::error ::')
+                ->contains($truth);
+        },
+    )->tag(Tag::ci);
+
     yield proof(
         'Printer->proof()->failure() for Failure\Property',
+        given(
+            Set\Strings::any(),
+            Set\Strings::madeOf(Set\Chars::alphanumerical()),
+            Set\Strings::madeOf(Set\Chars::alphanumerical()),
+            Set\Strings::any(),
+        ),
+        static function($assert, $name, $property, $val, $message) {
+            $printer = Standard::new()->disableGitHubGrouping();
+            $io = Collect::new();
+
+            $printer
+                ->proof($io, $io, Name::of($name), [])
+                ->failed($io, $io, Failure::of(
+                    Assert\Failure::of(Property::of(
+                        $property,
+                        $message,
+                    )),
+                    Value::immutable(Scenario\Inline::of(
+                        [$val],
+                        static fn($assert, $foo) => null,
+                    )),
+                ));
+
+            $written = $io->toString();
+
+            $assert
+                ->string($written)
+                ->contains("F\n\n")
+                ->contains('$variable = ')
+                ->contains($property)
+                ->contains('$foo = ')
+                ->contains($val)
+                ->contains($message);
+        },
+    )->tag(Tag::ci, Tag::local);
+
+    yield proof(
+        'Printer->proof()->failure() for Failure\Property in GitHub Action',
         given(
             Set\Strings::any(),
             Set\Strings::madeOf(Set\Chars::alphanumerical()),
@@ -333,11 +405,55 @@ return static function() {
                 ->contains($property)
                 ->contains('$foo = ')
                 ->contains($val)
+                ->contains('::error ::')
+                ->contains($message);
+        },
+    )->tag(Tag::ci);
+
+    yield proof(
+        'Printer->proof()->failure() for Failure\Comparison',
+        given(
+            Set\Strings::any(),
+            Set\Strings::madeOf(Set\Chars::alphanumerical()),
+            Set\Strings::madeOf(Set\Chars::alphanumerical()),
+            Set\Strings::madeOf(Set\Chars::alphanumerical()),
+            Set\Strings::any(),
+        ),
+        static function($assert, $name, $expected, $actual, $val, $message) {
+            $printer = Standard::new()->disableGitHubGrouping();
+            $io = Collect::new();
+
+            $printer
+                ->proof($io, $io, Name::of($name), [])
+                ->failed($io, $io, Failure::of(
+                    Assert\Failure::of(Comparison::of(
+                        $expected,
+                        $actual,
+                        $message,
+                    )),
+                    Value::immutable(Scenario\Inline::of(
+                        [$val],
+                        static fn($assert, $foo) => null,
+                    )),
+                ));
+
+            $written = $io->toString();
+
+            $assert
+                ->string($written)
+                ->contains("F\n\n")
+                ->contains('$expected = ')
+                ->contains($expected)
+                ->contains('$actual = ')
+                ->contains($actual)
+                ->contains('$foo = ')
+                ->contains($val)
                 ->contains($message);
         },
     )->tag(Tag::ci, Tag::local);
+
     yield proof(
-        'Printer->proof()->failure() for Failure\Comparison',
+        'Printer->proof()->failure() for Failure\Comparison in GitHub Action',
         given(
             Set\Strings::any(),
             Set\Strings::madeOf(Set\Chars::alphanumerical()),
@@ -374,9 +490,11 @@ return static function() {
                 ->contains($actual)
                 ->contains('$foo = ')
                 ->contains($val)
+                ->contains('::error ::')
                 ->contains($message);
         },
-    )->tag(Tag::ci, Tag::local);
+    )->tag(Tag::ci);
+
     yield proof(
         'Printer->proof()->failure() for Scenario\Property',
         given(

--- a/proofs/runner/printer.php
+++ b/proofs/runner/printer.php
@@ -218,11 +218,11 @@ return static function() {
                 ->proof($io, $io, Name::of($name), $tags)
                 ->emptySet($io, $io);
 
-            $written = $io->written();
+            $written = \implode('', $io->written());
 
             $assert
-                ->expected("No scenario found\n::endgroup::\n")
-                ->same(\end($written));
+                ->string($written)
+                ->endsWith("No scenario found\n::endgroup::\n");
         },
     )->tag(Tag::ci);
 
@@ -477,11 +477,11 @@ return static function() {
                 ->proof($io, $io, Name::of($name), $tags)
                 ->end($io, $io);
 
-            $written = $io->written();
+            $written = \implode('', $io->written());
 
             $assert
-                ->expected("\n\n::endgroup::\n")
-                ->same(\end($written));
+                ->string($written)
+                ->endsWith("\n\n::endgroup::\n");
         },
     )->tag(Tag::ci);
 };

--- a/proofs/runner/printer.php
+++ b/proofs/runner/printer.php
@@ -483,5 +483,5 @@ return static function() {
                 ->expected("\n\n::endgroup::\n")
                 ->same(\end($written));
         },
-    )->tag(Tag::ci, Tag::local);
+    )->tag(Tag::ci);
 };

--- a/src/Runner/Printer/Proof/Standard.php
+++ b/src/Runner/Printer/Proof/Standard.php
@@ -146,7 +146,7 @@ final class Standard implements Proof
             $output("::endgroup::\n");
 
             if ($this->failed) {
-                $output("::error ::Failing proof 👆\n");
+                $output("::error title=Error title::Failing proof 👆\n");
             }
         }
     }

--- a/src/Runner/Printer/Proof/Standard.php
+++ b/src/Runner/Printer/Proof/Standard.php
@@ -146,7 +146,7 @@ final class Standard implements Proof
             $output("::endgroup::\n");
 
             if ($this->failed) {
-                $output("::error ::Failing proof 👆");
+                $output("::error ::Failing proof 👆\n");
             }
         }
     }

--- a/src/Runner/Printer/Proof/Standard.php
+++ b/src/Runner/Printer/Proof/Standard.php
@@ -85,7 +85,11 @@ final class Standard implements Proof
         $this->renderFailure($output, $failure->assertion()->kind());
 
         $output(\sprintf(
-            "\n%s\n",
+            "\n%s%s\n",
+            match ($this->addGroups) {
+                true => '::error ::',
+                false => '',
+            },
             $failure->assertion()->kind()->message(),
         ));
 
@@ -101,8 +105,6 @@ final class Standard implements Proof
         if ($this->addMarks) {
             $output("\x1b]1337;SetMark\x07");
         }
-
-        $githubErrorRendered = false;
 
         foreach ($trace as $frame) {
             if (!\array_key_exists('file', $frame)) {
@@ -131,14 +133,6 @@ final class Standard implements Proof
                 \str_contains($frame['file'], '/runner/work/BlackBox/BlackBox/src/PHPUnit')
             ) {
                 continue;
-            }
-
-            if ($this->addGroups && !$githubErrorRendered) {
-                $output(\sprintf(
-                    '::error title=%s::',
-                    $this->proof,
-                ));
-                $githubErrorRendered = true;
             }
 
             $output(\sprintf(

--- a/src/Runner/Printer/Proof/Standard.php
+++ b/src/Runner/Printer/Proof/Standard.php
@@ -133,6 +133,10 @@ final class Standard implements Proof
                 $frame['line'],
             ));
         }
+
+        if ($this->addGroups) {
+            $output("::error ::Failing proof");
+        }
     }
 
     public function end(IO $output, IO $error): void

--- a/src/Runner/Printer/Proof/Standard.php
+++ b/src/Runner/Printer/Proof/Standard.php
@@ -25,25 +25,37 @@ final class Standard implements Proof
     private CliDumper $dumper;
     private VarCloner $cloner;
     private bool $addMarks;
+    private bool $addGroups;
     private int $scenarii = 0;
 
-    private function __construct(bool $withColors, bool $addMarks)
-    {
+    private function __construct(
+        bool $withColors,
+        bool $addMarks,
+        bool $addGroups,
+    ) {
         $this->dumper = new CliDumper;
         $this->cloner = new VarCloner;
         $this->addMarks = $addMarks;
+        $this->addGroups = $addGroups;
         $this->dumper->setColors($withColors);
         $this->cloner->setMinDepth(100);
     }
 
-    public static function new(bool $withColors, bool $addMarks): self
-    {
-        return new self($withColors, $addMarks);
+    public static function new(
+        bool $withColors,
+        bool $addMarks,
+        bool $addGroups,
+    ): self {
+        return new self($withColors, $addMarks, $addGroups);
     }
 
     public function emptySet(IO $output, IO $error): void
     {
         $error("No scenario found\n");
+
+        if ($this->addGroups) {
+            $output("::endgroup::\n");
+        }
     }
 
     public function success(IO $output, IO $error): void
@@ -126,6 +138,10 @@ final class Standard implements Proof
     public function end(IO $output, IO $error): void
     {
         $output("\n\n");
+
+        if ($this->addGroups) {
+            $output("::endgroup::\n");
+        }
     }
 
     private function newLine(IO $output): void

--- a/src/Runner/Printer/Proof/Standard.php
+++ b/src/Runner/Printer/Proof/Standard.php
@@ -150,7 +150,7 @@ final class Standard implements Proof
             $output("::endgroup::\n");
 
             if ($this->failed) {
-                $output("::error ::{$this->proof} failed 👆\n");
+                $output("::error ::🚨 {$this->proof} failed 🚨\n");
             }
         }
     }

--- a/src/Runner/Printer/Proof/Standard.php
+++ b/src/Runner/Printer/Proof/Standard.php
@@ -146,7 +146,7 @@ final class Standard implements Proof
             $output("::endgroup::\n");
 
             if ($this->failed) {
-                $output("::error title=Error title::Failing proof 👆\n");
+                $output("::error ::Failing proof 👆\n");
             }
         }
     }

--- a/src/Runner/Printer/Proof/Standard.php
+++ b/src/Runner/Printer/Proof/Standard.php
@@ -135,9 +135,7 @@ final class Standard implements Proof
 
             if ($this->addGroups && !$githubErrorRendered) {
                 $output(\sprintf(
-                    '::error file=%s,line=%s,title=%s::',
-                    $frame['file'],
-                    $frame['line'],
+                    '::error title=%s::',
                     $this->proof,
                 ));
                 $githubErrorRendered = true;

--- a/src/Runner/Printer/Proof/Standard.php
+++ b/src/Runner/Printer/Proof/Standard.php
@@ -24,12 +24,14 @@ final class Standard implements Proof
 {
     private CliDumper $dumper;
     private VarCloner $cloner;
+    private string $proof;
     private bool $addMarks;
     private bool $addGroups;
     private int $scenarii = 0;
     private bool $failed = false;
 
     private function __construct(
+        string $proof,
         bool $withColors,
         bool $addMarks,
         bool $addGroups,
@@ -43,11 +45,12 @@ final class Standard implements Proof
     }
 
     public static function new(
+        string $proof,
         bool $withColors,
         bool $addMarks,
         bool $addGroups,
     ): self {
-        return new self($withColors, $addMarks, $addGroups);
+        return new self($proof, $withColors, $addMarks, $addGroups);
     }
 
     public function emptySet(IO $output, IO $error): void
@@ -146,7 +149,7 @@ final class Standard implements Proof
             $output("::endgroup::\n");
 
             if ($this->failed) {
-                $output("::error ::Failing proof 👆\n");
+                $output("::error ::{$this->proof} failed 👆\n");
             }
         }
     }

--- a/src/Runner/Printer/Proof/Standard.php
+++ b/src/Runner/Printer/Proof/Standard.php
@@ -27,6 +27,7 @@ final class Standard implements Proof
     private bool $addMarks;
     private bool $addGroups;
     private int $scenarii = 0;
+    private bool $failed = false;
 
     private function __construct(
         bool $withColors,
@@ -134,9 +135,7 @@ final class Standard implements Proof
             ));
         }
 
-        if ($this->addGroups) {
-            $output("::error ::Failing proof");
-        }
+        $this->failed = true;
     }
 
     public function end(IO $output, IO $error): void
@@ -145,6 +144,10 @@ final class Standard implements Proof
 
         if ($this->addGroups) {
             $output("::endgroup::\n");
+
+            if ($this->failed) {
+                $output("::error ::Failing proof 👆");
+            }
         }
     }
 

--- a/src/Runner/Printer/Proof/Standard.php
+++ b/src/Runner/Printer/Proof/Standard.php
@@ -38,6 +38,7 @@ final class Standard implements Proof
     ) {
         $this->dumper = new CliDumper;
         $this->cloner = new VarCloner;
+        $this->proof = $proof;
         $this->addMarks = $addMarks;
         $this->addGroups = $addGroups;
         $this->dumper->setColors($withColors);

--- a/src/Runner/Printer/Proof/Standard.php
+++ b/src/Runner/Printer/Proof/Standard.php
@@ -24,20 +24,17 @@ final class Standard implements Proof
 {
     private CliDumper $dumper;
     private VarCloner $cloner;
-    private string $proof;
     private bool $addMarks;
     private bool $addGroups;
     private int $scenarii = 0;
 
     private function __construct(
-        string $proof,
         bool $withColors,
         bool $addMarks,
         bool $addGroups,
     ) {
         $this->dumper = new CliDumper;
         $this->cloner = new VarCloner;
-        $this->proof = $proof;
         $this->addMarks = $addMarks;
         $this->addGroups = $addGroups;
         $this->dumper->setColors($withColors);
@@ -45,12 +42,11 @@ final class Standard implements Proof
     }
 
     public static function new(
-        string $proof,
         bool $withColors,
         bool $addMarks,
         bool $addGroups,
     ): self {
-        return new self($proof, $withColors, $addMarks, $addGroups);
+        return new self($withColors, $addMarks, $addGroups);
     }
 
     public function emptySet(IO $output, IO $error): void

--- a/src/Runner/Printer/Standard.php
+++ b/src/Runner/Printer/Standard.php
@@ -88,6 +88,7 @@ final class Standard implements Printer
         $output($header);
 
         return Printer\Proof\Standard::new(
+            $proof->toString(),
             $this->withColors,
             $this->addMarks,
             $this->addGroups,

--- a/src/Runner/Printer/Standard.php
+++ b/src/Runner/Printer/Standard.php
@@ -19,12 +19,14 @@ final class Standard implements Printer
     private Timer $timer;
     private bool $withColors;
     private bool $addMarks;
+    private bool $addGroups;
 
     private function __construct(bool $withColors)
     {
         $this->timer = new Timer;
         $this->withColors = $withColors;
         $this->addMarks = \getenv('LC_TERMINAL') === 'iTerm2';
+        $this->addGroups = \getenv('GITHUB_ACTIONS') === 'true';
     }
 
     /**
@@ -53,17 +55,29 @@ final class Standard implements Printer
         Proof\Name $proof,
         array $tags,
     ): Printer\Proof {
+        $header = '';
+
         foreach ($tags as $tag) {
-            $output("[{$tag->name}]");
+            $header .= "[{$tag->name}]";
         }
 
         if (\count($tags) > 0) {
-            $output(' ');
+            $header .= ' ';
         }
 
-        $output($proof->toString().":\n");
+        $header .= $proof->toString().":\n";
 
-        return Printer\Proof\Standard::new($this->withColors, $this->addMarks);
+        if ($this->addGroups) {
+            $header = '::group::'.$header;
+        }
+
+        $output($header);
+
+        return Printer\Proof\Standard::new(
+            $this->withColors,
+            $this->addMarks,
+            $this->addGroups,
+        );
     }
 
     public function end(IO $output, IO $error, Stats $stats): void

--- a/src/Runner/Printer/Standard.php
+++ b/src/Runner/Printer/Standard.php
@@ -46,7 +46,7 @@ final class Standard implements Printer
         return new self(false);
     }
 
-    public function disableGitHubGrouping(): self
+    public function disableGitHubOutput(): self
     {
         return new self(
             $this->withColors,

--- a/src/Runner/Printer/Standard.php
+++ b/src/Runner/Printer/Standard.php
@@ -88,7 +88,6 @@ final class Standard implements Printer
         $output($header);
 
         return Printer\Proof\Standard::new(
-            $proof->toString(),
             $this->withColors,
             $this->addMarks,
             $this->addGroups,

--- a/src/Runner/Printer/Standard.php
+++ b/src/Runner/Printer/Standard.php
@@ -21,12 +21,16 @@ final class Standard implements Printer
     private bool $addMarks;
     private bool $addGroups;
 
-    private function __construct(bool $withColors)
-    {
-        $this->timer = new Timer;
+    private function __construct(
+        bool $withColors,
+        ?Timer $timer = null,
+        ?bool $addMarks = null,
+        ?bool $addGroups = null,
+    ) {
+        $this->timer = $timer ?? new Timer;
         $this->withColors = $withColors;
-        $this->addMarks = \getenv('LC_TERMINAL') === 'iTerm2';
-        $this->addGroups = \getenv('GITHUB_ACTIONS') === 'true';
+        $this->addMarks = $addMarks ?? \getenv('LC_TERMINAL') === 'iTerm2';
+        $this->addGroups = $addGroups ?? \getenv('GITHUB_ACTIONS') === 'true';
     }
 
     /**
@@ -40,6 +44,16 @@ final class Standard implements Printer
     public static function withoutColors(): self
     {
         return new self(false);
+    }
+
+    public function disableGitHubGrouping(): self
+    {
+        return new self(
+            $this->withColors,
+            $this->timer,
+            $this->addMarks,
+            false,
+        );
     }
 
     public function start(IO $output, IO $error): void


### PR DESCRIPTION
## Request

Fixes #20 

## Implementation

Each proof is now its own group with the proof name as group title.

When a proof fails an error annotation is set on the failure message. This adds an annotation at the top of the workflow that will jump to the exact line that failed (and opening the group it's in).

Examples:

![Screenshot 2024-11-29 at 19 22 08](https://github.com/user-attachments/assets/0bb83921-3817-4f56-9490-3926868c5340)
![Screenshot 2024-11-29 at 19 22 15](https://github.com/user-attachments/assets/9a28ed1e-2ea4-4212-9cc4-a97fcfe41dc4)
![Screenshot 2024-11-29 at 19 22 33](https://github.com/user-attachments/assets/8e88d021-bbf9-4aca-b213-253c888236c7)
