### PR TITLE
Add support for PHPUnit 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,33 @@ jobs:
       - uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+  phpunit_11:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        php-version: ['8.2', '8.3']
+        dependency-versions: ['lowest', 'highest']
+    name: 'PHPUnit 11'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          extensions: mbstring, intl
+          coverage: xdebug
+      - name: Composer
+        uses: "ramsey/composer-install@v3"
+        with:
+          dependency-versions: ${{ matrix.dependencies }}
+          composer-options: '--no-dev'
+      - name: PHPUnit
+        run: vendor/bin/phpunit --fail-on-risky --coverage-clover=coverage.clover
+      - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
   psalm:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
           dependency-versions: ${{ matrix.dependencies }}
           composer-options: '--no-dev'
       - name: 'Remove conflict on Psalm'
-        run: composer remove --dev vimeo/psalm
+        run: composer remove --dev vimeo/psalm && composer update
       - name: PHPUnit
         run: vendor/bin/phpunit --fail-on-risky --coverage-clover=coverage.clover
       - uses: codecov/codecov-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,8 @@ jobs:
         with:
           dependency-versions: ${{ matrix.dependencies }}
           composer-options: '--no-dev'
+      - name: 'Remove conflict on Psalm'
+        run: composer remove --dev vimeo/psalm
       - name: PHPUnit
         run: vendor/bin/phpunit --fail-on-risky --coverage-clover=coverage.clover
       - uses: codecov/codecov-action@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- Support for PHPUnit 11
+
 ## 5.9.0 - 2024-11-29
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
         "php": "~8.2",
         "innmind/json": "^1.1",
         "symfony/var-dumper": "~6.0|~7.0",
-        "phpunit/phpunit": "~10.0",
-        "phpunit/php-timer": "^6.0",
-        "phpunit/php-code-coverage": "^10.1"
+        "phpunit/phpunit": "~10.0|~11.0",
+        "phpunit/php-timer": "~6.0|~7.0",
+        "phpunit/php-code-coverage": "~10.1|~11.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Psalm is removed in the PHPUnit 11 job because there's a conflict on `nikic/php-parser` where PHPUnit requires the major 5 and Psalm 4.

This problem should not affect the packages using BlackBox as the dev requirements are ignored.