### PR TITLE
Add PHPUnit 12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,35 +40,6 @@ jobs:
       - uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-  phpunit_11:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macOS-latest]
-        php-version: ['8.2', '8.3', '8.4']
-        dependency-versions: ['lowest', 'highest']
-    name: 'PHPUnit 11'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-version }}
-          extensions: mbstring, intl
-          coverage: xdebug
-      - name: Composer
-        uses: "ramsey/composer-install@v3"
-        with:
-          dependency-versions: ${{ matrix.dependencies }}
-          composer-options: '--no-dev'
-      - name: 'Remove conflict on Psalm'
-        run: composer remove --dev innmind/static-analysis && composer update
-      - name: PHPUnit
-        run: vendor/bin/phpunit --fail-on-risky --coverage-clover=coverage.clover
-      - uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
   psalm:
     uses: innmind/github-workflows/.github/workflows/psalm-matrix.yml@main
   cs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `Innmind\BlackBox\Set\Provider` to allow classes to be factories of `Set`s without having to implement the `Set` interface
+- Support for PHPUnit `12`
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
         "php": "~8.2",
         "innmind/json": "^1.1",
         "symfony/var-dumper": "~6.0|~7.0",
-        "phpunit/phpunit": "~10.0|~11.0",
-        "phpunit/php-timer": "~6.0|~7.0",
-        "phpunit/php-code-coverage": "~10.1|~11.0"
+        "phpunit/phpunit": "~10.0|~11.0|~12.0",
+        "phpunit/php-timer": "~6.0|~7.0|~8.0",
+        "phpunit/php-code-coverage": "~10.1|~11.0|~12.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The PHPUnit 11 job has been removed as there's no longer a conflict with psalm.