### PR TITLE
Add `Set::flatMap()`

### DIFF
--- a/proofs/set.php
+++ b/proofs/set.php
@@ -1,0 +1,144 @@
+<?php
+declare(strict_types = 1);
+
+use Innmind\BlackBox\{
+    Set,
+    Random,
+    Tag,
+};
+
+return static function() {
+    $anySet = Set::of(
+        Set::integers()->toSet(),
+        // real numbers not used as it may return the type integer
+        Set::strings()->toSet(),
+        Set::sequence(Set::either(
+            Set::integers()->toSet(),
+            // real numbers not used as it may return the type integer
+            Set::strings()->toSet(),
+        ))->between(0, 10)->toSet(),
+        Set::of(true, false),
+    );
+
+    yield proof(
+        'Set::flatMap() input is of the type of the parent',
+        given($anySet, $anySet),
+        static function($assert, $input, $output) {
+            $compose = $input->flatMap(static function($value) use ($assert, $input, $output) {
+                $assert->same(
+                    \gettype($value),
+                    \gettype($input->values(Random::default)->current()->unwrap()),
+                );
+
+                return $output;
+            });
+
+            foreach ($compose->values(Random::default) as $_) {
+                // triggers the assert in the flatMap lambda
+            }
+        },
+    )->tag(Tag::ci, Tag::local);
+
+    yield proof(
+        'Set::flatMap() values is of the type of the child set',
+        given($anySet, $anySet),
+        static function($assert, $input, $output) {
+            $compose = $input->flatMap(static fn() => $output);
+
+            foreach ($compose->values(Random::default) as $value) {
+                $assert->same(
+                    \gettype($value->unwrap()),
+                    \gettype($output->values(Random::default)->current()->unwrap()),
+                );
+            }
+        },
+    )->tag(Tag::ci, Tag::local);
+
+    yield proof(
+        'Set::flatMap()->take()',
+        given($anySet, $anySet, Set::integers()->between(1, 100)),
+        static function($assert, $input, $output, $size) {
+            $compose = $input
+                ->flatMap(static fn() => $output)
+                ->take($size);
+            $count = 0;
+
+            foreach ($compose->values(Random::default) as $_) {
+                ++$count;
+            }
+
+            $assert->same($size, $count);
+        },
+    )->tag(Tag::ci, Tag::local);
+
+    yield proof(
+        'Set::flatMap()->filter() is applied on the child values',
+        given($anySet, $anySet),
+        static function($assert, $input, $output) {
+            $expected = \gettype($output->values(Random::default)->current()->unwrap());
+            $compose = $input
+                ->flatMap(static fn() => $output)
+                ->filter(static function($value) use ($assert, $expected) {
+                    $assert->same(
+                        $expected,
+                        \gettype($value),
+                    );
+
+                    return true;
+                });
+
+            foreach ($compose->values(Random::default) as $_) {
+                // triggers the assert in the filter lambda
+            }
+        },
+    )->tag(Tag::ci, Tag::local);
+
+    yield proof(
+        'Set::flatMap()->map()',
+        given($anySet, Set::of(Set::integers()->between(-1_000_000, 1_000_000))),
+        static function($assert, $input, $output) {
+            $compose = $input
+                ->flatMap(static fn() => $output)
+                ->map(static fn($i) => $i*2);
+
+            foreach ($compose->values(Random::default) as $value) {
+                $assert->same(
+                    0,
+                    $value->unwrap() % 2,
+                );
+            }
+        },
+    )->tag(Tag::ci, Tag::local);
+
+    yield proof(
+        'Set::flatMap() input value is always the same',
+        given(
+            Set::of(
+                Set::integers()->toSet(),
+                Set::realNumbers()->toSet(),
+                Set::strings()->toSet(),
+                Set::sequence(Set::either(
+                    Set::integers()->toSet(),
+                    Set::realNumbers()->toSet(),
+                    Set::strings()->toSet(),
+                ))->between(0, 10)->toSet(),
+            ),
+            $anySet,
+        ),
+        static function($assert, $input, $output) {
+            $compose = $input->flatMap(static fn($value) => $output->map(
+                static fn() => $value,
+            ));
+            $values = [];
+
+            foreach ($compose->values(Random::default) as $value) {
+                $values[] = $value->unwrap();
+            }
+
+            $assert->count(
+                1,
+                \array_unique($values, \SORT_REGULAR),
+            );
+        },
+    )->tag(Tag::ci, Tag::local);
+};

--- a/proofs/set.php
+++ b/proofs/set.php
@@ -114,14 +114,14 @@ return static function() {
         'Set::flatMap() input value is always the same',
         given(
             Set::of(
-                Set::integers()->toSet(),
-                Set::realNumbers()->toSet(),
-                Set::strings()->toSet(),
+                Set::integers(),
+                Set::realNumbers(),
+                Set::strings(),
                 Set::sequence(Set::either(
-                    Set::integers()->toSet(),
-                    Set::realNumbers()->toSet(),
-                    Set::strings()->toSet(),
-                ))->between(0, 10)->toSet(),
+                    Set::integers(),
+                    Set::realNumbers(),
+                    Set::strings(),
+                ))->between(0, 10),
             ),
             $anySet,
         ),

--- a/src/Set.php
+++ b/src/Set.php
@@ -459,6 +459,30 @@ final class Set
     }
 
     /**
+     * This allows to configure a Set from a randomly generated value from the
+     * current Set.
+     *
+     * Note that the value generated for the input won't be shrunk. The more
+     * your values comes from this composition the less values will be
+     * shrinkable.
+     *
+     * @psalm-mutation-free
+     *
+     * @template V
+     *
+     * @param callable(T): (self<V>|Provider<V>) $map
+     *
+     * @return self<V>
+     */
+    public function flatMap(callable $map): self
+    {
+        return new self($this->implementation->flatMap(
+            $map,
+            static fn(self|Provider $set) => Collapse::of($set)->implementation,
+        ));
+    }
+
+    /**
      * @internal End users mustn't use this method directly (BC breaks may be introduced)
      *
      * @throws EmptySet When no value can be generated

--- a/src/Set/Composite.php
+++ b/src/Set/Composite.php
@@ -163,6 +163,19 @@ final class Composite implements Implementation
         return Decorate::implementation($map, $this, true);
     }
 
+    /**
+     * @psalm-mutation-free
+     */
+    #[\Override]
+    public function flatMap(callable $map, callable $extract): Implementation
+    {
+        /** @psalm-suppress MixedArgument Due to $input */
+        return FlatMap::implementation(
+            static fn($input) => $extract($map($input)),
+            $this,
+        );
+    }
+
     #[\Override]
     public function values(Random $random): \Generator
     {

--- a/src/Set/Decorate.php
+++ b/src/Set/Decorate.php
@@ -129,6 +129,19 @@ final class Decorate implements Implementation
         );
     }
 
+    /**
+     * @psalm-mutation-free
+     */
+    #[\Override]
+    public function flatMap(callable $map, callable $extract): Implementation
+    {
+        /** @psalm-suppress MixedArgument Due to $input */
+        return FlatMap::implementation(
+            static fn($input) => $extract($map($input)),
+            $this,
+        );
+    }
+
     #[\Override]
     public function values(Random $random): \Generator
     {

--- a/src/Set/Either.php
+++ b/src/Set/Either.php
@@ -140,6 +140,19 @@ final class Either implements Implementation
         return Decorate::implementation($map, $this, true);
     }
 
+    /**
+     * @psalm-mutation-free
+     */
+    #[\Override]
+    public function flatMap(callable $map, callable $extract): Implementation
+    {
+        /** @psalm-suppress MixedArgument Due to $input */
+        return FlatMap::implementation(
+            static fn($input) => $extract($map($input)),
+            $this,
+        );
+    }
+
     #[\Override]
     public function values(Random $random): \Generator
     {

--- a/src/Set/Elements.php
+++ b/src/Set/Elements.php
@@ -133,6 +133,19 @@ final class Elements implements Implementation
         return Decorate::implementation($map, $this, true);
     }
 
+    /**
+     * @psalm-mutation-free
+     */
+    #[\Override]
+    public function flatMap(callable $map, callable $extract): Implementation
+    {
+        /** @psalm-suppress MixedArgument Due to $input */
+        return FlatMap::implementation(
+            static fn($input) => $extract($map($input)),
+            $this,
+        );
+    }
+
     #[\Override]
     public function values(Random $random): \Generator
     {

--- a/src/Set/FlatMap.php
+++ b/src/Set/FlatMap.php
@@ -1,0 +1,130 @@
+<?php
+declare(strict_types = 1);
+
+namespace Innmind\BlackBox\Set;
+
+use Innmind\BlackBox\{
+    Set,
+    Random,
+};
+
+/**
+ * @internal
+ * @template D
+ * @template I
+ * @implements Implementation<D>
+ */
+final class FlatMap implements Implementation
+{
+    /**
+     * @psalm-mutation-free
+     *
+     * @param \Closure(I): Implementation<D> $decorate
+     * @param Implementation<I> $set
+     */
+    private function __construct(
+        private \Closure $decorate,
+        private Implementation $set,
+        private int $size,
+    ) {
+    }
+
+    /**
+     * @internal
+     * @psalm-pure
+     *
+     * @template T
+     * @template V
+     *
+     * @param callable(V): Implementation<T> $decorate It must be a pure function (no randomness, no side effects)
+     * @param Implementation<V> $set
+     *
+     * @return self<T,V>
+     */
+    public static function implementation(
+        callable $decorate,
+        Implementation $set,
+    ): self {
+        return new self(\Closure::fromCallable($decorate), $set, 100);
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    #[\Override]
+    public function take(int $size): self
+    {
+        $decorate = $this->decorate;
+
+        /** @psalm-suppress MixedArgument */
+        return new self(
+            static fn($value) => $decorate($value)->take($size),
+            $this->set->take($size),
+            $size,
+        );
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    #[\Override]
+    public function filter(callable $predicate): self
+    {
+        $decorate = $this->decorate;
+
+        /** @psalm-suppress MixedArgument */
+        return new self(
+            static fn($value) => $decorate($value)->filter($predicate),
+            $this->set,
+            $this->size,
+        );
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    #[\Override]
+    public function map(callable $map): Implementation
+    {
+        return Decorate::implementation(
+            $map,
+            $this,
+            true,
+        );
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    #[\Override]
+    public function flatMap(callable $map, callable $extract): self
+    {
+        /** @psalm-suppress MixedArgument Due to $input */
+        return self::implementation(
+            static fn($input) => $extract($map($input)),
+            $this,
+        );
+    }
+
+    #[\Override]
+    public function values(Random $random): \Generator
+    {
+        $iterations = 0;
+
+        // By default we favor reusing the same seed to generate multiple values
+        // from the underlying set. To generate a more wide range of seeds one
+        // can use the ->randomize() method.
+        foreach ($this->set->values($random) as $seed) {
+            $set = ($this->decorate)($seed->unwrap());
+
+            foreach ($set->values($random) as $value) {
+                yield $value;
+                ++$iterations;
+
+                if ($iterations === $this->size) {
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/src/Set/FromGenerator.php
+++ b/src/Set/FromGenerator.php
@@ -143,6 +143,19 @@ final class FromGenerator implements Implementation
         return Decorate::implementation($map, $this, $this->immutable);
     }
 
+    /**
+     * @psalm-mutation-free
+     */
+    #[\Override]
+    public function flatMap(callable $map, callable $extract): Implementation
+    {
+        /** @psalm-suppress MixedArgument Due to $input */
+        return FlatMap::implementation(
+            static fn($input) => $extract($map($input)),
+            $this,
+        );
+    }
+
     #[\Override]
     public function values(Random $random): \Generator
     {

--- a/src/Set/Implementation.php
+++ b/src/Set/Implementation.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace Innmind\BlackBox\Set;
 
 use Innmind\BlackBox\{
+    Set,
     Random,
     Exception\EmptySet,
 };
@@ -42,6 +43,18 @@ interface Implementation
      * @return self<V>
      */
     public function map(callable $map): self;
+
+    /**
+     * @psalm-mutation-free
+     *
+     * @template V
+     *
+     * @param callable(T): (Set<V>|Provider<V>) $map
+     * @param callable(Set<V>|Provider<V>): self<V> $extract
+     *
+     * @return self<V>
+     */
+    public function flatMap(callable $map, callable $extract): self;
 
     /**
      * @throws EmptySet When no value can be generated

--- a/src/Set/Integers.php
+++ b/src/Set/Integers.php
@@ -154,6 +154,18 @@ final class Integers implements Implementation
         return Decorate::implementation($map, $this, true);
     }
 
+    /**
+     * @psalm-mutation-free
+     */
+    #[\Override]
+    public function flatMap(callable $map, callable $extract): Implementation
+    {
+        return FlatMap::implementation(
+            static fn(int $input) => $extract($map($input)),
+            $this,
+        );
+    }
+
     #[\Override]
     public function values(Random $random): \Generator
     {

--- a/src/Set/MadeOf.php
+++ b/src/Set/MadeOf.php
@@ -121,6 +121,20 @@ final class MadeOf implements Provider
     /**
      * @psalm-mutation-free
      *
+     * @template V
+     *
+     * @param callable(string): (Set<V>|Provider<V>) $map
+     *
+     * @return Set<V>
+     */
+    public function flatMap(callable $map): Set
+    {
+        return $this->toSet()->flatMap($map);
+    }
+
+    /**
+     * @psalm-mutation-free
+     *
      * @return Set<string>
      */
     #[\Override]

--- a/src/Set/Properties.php
+++ b/src/Set/Properties.php
@@ -97,6 +97,20 @@ final class Properties implements Provider
     /**
      * @psalm-mutation-free
      *
+     * @template V
+     *
+     * @param callable(Ensure): (Set<V>|Provider<V>) $map
+     *
+     * @return Set<V>
+     */
+    public function flatMap(callable $map): Set
+    {
+        return $this->toSet()->flatMap($map);
+    }
+
+    /**
+     * @psalm-mutation-free
+     *
      * @return Set<Ensure>
      */
     #[\Override]

--- a/src/Set/Provider/Composite.php
+++ b/src/Set/Provider/Composite.php
@@ -127,6 +127,20 @@ final class Composite implements Provider
 
     /**
      * @psalm-mutation-free
+     *
+     * @template V
+     *
+     * @param callable(T): (Set<V>|Provider<V>) $map
+     *
+     * @return Set<V>
+     */
+    public function flatMap(callable $map): Set
+    {
+        return $this->toSet()->flatMap($map);
+    }
+
+    /**
+     * @psalm-mutation-free
      */
     #[\Override]
     public function toSet(): Set

--- a/src/Set/Provider/Generator.php
+++ b/src/Set/Provider/Generator.php
@@ -115,6 +115,20 @@ final class Generator implements Provider
 
     /**
      * @psalm-mutation-free
+     *
+     * @template V
+     *
+     * @param callable(T): (Set<V>|Provider<V>) $map
+     *
+     * @return Set<V>
+     */
+    public function flatMap(callable $map): Set
+    {
+        return $this->toSet()->flatMap($map);
+    }
+
+    /**
+     * @psalm-mutation-free
      */
     #[\Override]
     public function toSet(): Set

--- a/src/Set/Provider/Integers.php
+++ b/src/Set/Provider/Integers.php
@@ -139,6 +139,20 @@ final class Integers implements Provider
 
     /**
      * @psalm-mutation-free
+     *
+     * @template V
+     *
+     * @param callable(int): (Set<V>|Provider<V>) $map
+     *
+     * @return Set<V>
+     */
+    public function flatMap(callable $map): Set
+    {
+        return $this->toSet()->flatMap($map);
+    }
+
+    /**
+     * @psalm-mutation-free
      */
     #[\Override]
     public function toSet(): Set

--- a/src/Set/Provider/RealNumbers.php
+++ b/src/Set/Provider/RealNumbers.php
@@ -101,6 +101,20 @@ final class RealNumbers implements Provider
 
     /**
      * @psalm-mutation-free
+     *
+     * @template V
+     *
+     * @param callable(float): (Set<V>|Provider<V>) $map
+     *
+     * @return Set<V>
+     */
+    public function flatMap(callable $map): Set
+    {
+        return $this->toSet()->flatMap($map);
+    }
+
+    /**
+     * @psalm-mutation-free
      */
     #[\Override]
     public function toSet(): Set

--- a/src/Set/Provider/Sequence.php
+++ b/src/Set/Provider/Sequence.php
@@ -136,6 +136,20 @@ final class Sequence implements Provider
 
     /**
      * @psalm-mutation-free
+     *
+     * @template U
+     *
+     * @param callable(list<V>): (Set<U>|Provider<U>) $map
+     *
+     * @return Set<U>
+     */
+    public function flatMap(callable $map): Set
+    {
+        return $this->toSet()->flatMap($map);
+    }
+
+    /**
+     * @psalm-mutation-free
      */
     #[\Override]
     public function toSet(): Set

--- a/src/Set/Provider/Strings.php
+++ b/src/Set/Provider/Strings.php
@@ -153,6 +153,20 @@ final class Strings implements Provider
 
     /**
      * @psalm-mutation-free
+     *
+     * @template V
+     *
+     * @param callable(string): (Set<V>|Provider<V>) $map
+     *
+     * @return Set<V>
+     */
+    public function flatMap(callable $map): Set
+    {
+        return $this->toSet()->flatMap($map);
+    }
+
+    /**
+     * @psalm-mutation-free
      */
     #[\Override]
     public function toSet(): Set

--- a/src/Set/Provider/Strings/Chars.php
+++ b/src/Set/Provider/Strings/Chars.php
@@ -131,6 +131,20 @@ final class Chars implements Provider
 
     /**
      * @psalm-mutation-free
+     *
+     * @template V
+     *
+     * @param callable(non-empty-string): (Set<V>|Provider<V>) $map
+     *
+     * @return Set<V>
+     */
+    public function flatMap(callable $map): Set
+    {
+        return $this->toSet()->flatMap($map);
+    }
+
+    /**
+     * @psalm-mutation-free
      */
     #[\Override]
     public function toSet(): Set

--- a/src/Set/Provider/Strings/Unicode.php
+++ b/src/Set/Provider/Strings/Unicode.php
@@ -53,6 +53,7 @@ final class Unicode implements Provider
                     'take',
                     'filter',
                     'map',
+                    'flatMap',
                     'toSet',
                     'block',
                 ],
@@ -2896,6 +2897,20 @@ final class Unicode implements Provider
     public function map(callable $map): Set
     {
         return $this->toSet()->map($map);
+    }
+
+    /**
+     * @psalm-mutation-free
+     *
+     * @template V
+     *
+     * @param callable(string): (Set<V>|Provider<V>) $map
+     *
+     * @return Set<V>
+     */
+    public function flatMap(callable $map): Set
+    {
+        return $this->toSet()->flatMap($map);
     }
 
     /**

--- a/src/Set/Randomize.php
+++ b/src/Set/Randomize.php
@@ -96,6 +96,19 @@ final class Randomize implements Implementation
         return Decorate::implementation($map, $this, true);
     }
 
+    /**
+     * @psalm-mutation-free
+     */
+    #[\Override]
+    public function flatMap(callable $map, callable $extract): Implementation
+    {
+        /** @psalm-suppress MixedArgument Due to $input */
+        return FlatMap::implementation(
+            static fn($input) => $extract($map($input)),
+            $this,
+        );
+    }
+
     #[\Override]
     public function values(Random $random): \Generator
     {

--- a/src/Set/RealNumbers.php
+++ b/src/Set/RealNumbers.php
@@ -146,6 +146,18 @@ final class RealNumbers implements Implementation
         return Decorate::implementation($map, $this, true);
     }
 
+    /**
+     * @psalm-mutation-free
+     */
+    #[\Override]
+    public function flatMap(callable $map, callable $extract): Implementation
+    {
+        return FlatMap::implementation(
+            static fn(float $input) => $extract($map($input)),
+            $this,
+        );
+    }
+
     #[\Override]
     public function values(Random $random): \Generator
     {

--- a/src/Set/Sequence.php
+++ b/src/Set/Sequence.php
@@ -120,6 +120,19 @@ final class Sequence implements Implementation
         return Decorate::implementation($map, $this, true);
     }
 
+    /**
+     * @psalm-mutation-free
+     */
+    #[\Override]
+    public function flatMap(callable $map, callable $extract): Implementation
+    {
+        /** @psalm-suppress MixedArgument Due to $input */
+        return FlatMap::implementation(
+            static fn($input) => $extract($map($input)),
+            $this,
+        );
+    }
+
     #[\Override]
     public function values(Random $random): \Generator
     {

--- a/src/Set/Slice.php
+++ b/src/Set/Slice.php
@@ -108,6 +108,20 @@ final class Slice implements Provider
     /**
      * @psalm-mutation-free
      *
+     * @template V
+     *
+     * @param callable(Util): (Set<V>|Provider<V>) $map
+     *
+     * @return Set<V>
+     */
+    public function flatMap(callable $map): Set
+    {
+        return $this->toSet()->flatMap($map);
+    }
+
+    /**
+     * @psalm-mutation-free
+     *
      * @return Set<Util>
      */
     #[\Override]

--- a/src/Set/UnsafeStrings.php
+++ b/src/Set/UnsafeStrings.php
@@ -96,6 +96,18 @@ final class UnsafeStrings implements Implementation
         return Decorate::implementation($map, $this, true);
     }
 
+    /**
+     * @psalm-mutation-free
+     */
+    #[\Override]
+    public function flatMap(callable $map, callable $extract): Implementation
+    {
+        return FlatMap::implementation(
+            static fn(string $input) => $extract($map($input)),
+            $this,
+        );
+    }
+
     #[\Override]
     public function values(Random $random): \Generator
     {


### PR DESCRIPTION
## Request

#24 

## Implementation

- Adds `Set::flatMap()`
- Adds a `flatMap` shortcut on all implementations of `Set\Provider`

## Note

The current design has a major drawback. The _seed_ value, the one passed as argument to the `flatMap` callable can't be shrunk by BlackBox. Because once the user has access to it, the value can be modified/used in various ways that can't be replicated when shrinking values from the new `Set` created by `flatMap`.

A possible solution to fix this is that instead of directly providing the value to the user, it should be wrapped into a new monad (let's call it `Seed`) that would allow to track every transformation of this value. This monad could also have a simple `unwrap` method to access the value if the user doesn't care if the value is shrunk or not.

But this design requires a bit more investigation and will be done in another PR.