### PR TITLE
Simplify implementation of `Set::take()`

### DIFF
--- a/src/Set.php
+++ b/src/Set.php
@@ -502,7 +502,7 @@ final class Set
      */
     public function values(Random $random): \Generator
     {
-        yield from $this->implementation->values(
+        yield from ($this->implementation)(
             $random,
             static fn() => true,
             100,

--- a/src/Set.php
+++ b/src/Set.php
@@ -433,7 +433,10 @@ final class Set
      */
     public function take(int $size): self
     {
-        return new self($this->implementation->take($size));
+        return new self(Set\Take::implementation(
+            $this->implementation,
+            $size,
+        ));
     }
 
     /**

--- a/src/Set.php
+++ b/src/Set.php
@@ -505,6 +505,7 @@ final class Set
         yield from $this->implementation->values(
             $random,
             static fn() => true,
+            100,
         );
     }
 

--- a/src/Set/Composite.php
+++ b/src/Set/Composite.php
@@ -127,7 +127,7 @@ final class Composite implements Implementation
     }
 
     #[\Override]
-    public function values(Random $random, \Closure $predicate): \Generator
+    public function values(Random $random, \Closure $predicate, int $size): \Generator
     {
         $shrinker = Composite\Shrinker::new();
         $matrix = $this->matrix()->values($random);

--- a/src/Set/Composite.php
+++ b/src/Set/Composite.php
@@ -22,14 +22,12 @@ final class Composite implements Implementation
      *
      * @param \Closure(mixed...): (C|Seed<C>) $aggregate
      * @param list<Implementation> $sets
-     * @param ?int<1, max> $size
      */
     private function __construct(
         private \Closure $aggregate,
         private Implementation $first,
         private Implementation $second,
         private array $sets,
-        private ?int $size,
         private bool $immutable,
     ) {
     }
@@ -57,7 +55,6 @@ final class Composite implements Implementation
             $first,
             $second,
             $sets,
-            null, // by default allow all combinations
             $immutable,
         );
     }
@@ -106,26 +103,6 @@ final class Composite implements Implementation
             ->toSet();
     }
 
-    /**
-     * @psalm-mutation-free
-     *
-     * @param int<1, max> $size
-     *
-     * @return self<C>
-     */
-    #[\Override]
-    public function take(int $size): self
-    {
-        return new self(
-            $this->aggregate,
-            $this->first,
-            $this->second,
-            $this->sets,
-            $size,
-            $this->immutable,
-        );
-    }
-
     #[\Override]
     public function values(Random $random, \Closure $predicate, int $size): \Generator
     {
@@ -134,7 +111,7 @@ final class Composite implements Implementation
         $aggregate = $this->aggregate;
         $iterations = 0;
 
-        while ($matrix->valid() && $this->continue($iterations)) {
+        while ($matrix->valid() && $this->continue($iterations, $size)) {
             /** @var Composite\Combination */
             $combination = $matrix->current();
             $immutable = $combination->immutable() && $this->immutable;
@@ -174,12 +151,8 @@ final class Composite implements Implementation
         );
     }
 
-    private function continue(int $iterations): bool
+    private function continue(int $iterations, int $size): bool
     {
-        if (\is_null($this->size)) {
-            return true;
-        }
-
-        return $iterations < $this->size;
+        return $iterations < $size;
     }
 }

--- a/src/Set/Composite.php
+++ b/src/Set/Composite.php
@@ -104,8 +104,11 @@ final class Composite implements Implementation
     }
 
     #[\Override]
-    public function values(Random $random, \Closure $predicate, int $size): \Generator
-    {
+    public function __invoke(
+        Random $random,
+        \Closure $predicate,
+        int $size,
+    ): \Generator {
         $shrinker = Composite\Shrinker::new();
         $matrix = $this->matrix()->values($random);
         $aggregate = $this->aggregate;

--- a/src/Set/Composite/Matrix.php
+++ b/src/Set/Composite/Matrix.php
@@ -36,7 +36,7 @@ final class Matrix
         /** @var Implementation<Combination> */
         $combinations = FromGenerator::implementation(
             static function(Random $rand) use ($b): \Generator {
-                foreach ($b->values($rand, static fn() => true) as $value) {
+                foreach ($b->values($rand, static fn() => true, 100) as $value) {
                     yield Combination::startWith($value);
                 }
             },
@@ -64,8 +64,8 @@ final class Matrix
      */
     public function values(Random $rand): \Generator
     {
-        foreach ($this->a->values($rand, static fn() => true) as $a) {
-            foreach ($this->combinations->values($rand, static fn() => true) as $combination) {
+        foreach ($this->a->values($rand, static fn() => true, 100) as $a) {
+            foreach ($this->combinations->values($rand, static fn() => true, 100) as $combination) {
                 yield $combination->unwrap()->add($a);
             }
         }

--- a/src/Set/Composite/Matrix.php
+++ b/src/Set/Composite/Matrix.php
@@ -36,7 +36,7 @@ final class Matrix
         /** @var Implementation<Combination> */
         $combinations = FromGenerator::implementation(
             static function(Random $rand) use ($b): \Generator {
-                foreach ($b->values($rand, static fn() => true, 100) as $value) {
+                foreach ($b($rand, static fn() => true, 100) as $value) {
                     yield Combination::startWith($value);
                 }
             },
@@ -64,8 +64,8 @@ final class Matrix
      */
     public function values(Random $rand): \Generator
     {
-        foreach ($this->a->values($rand, static fn() => true, 100) as $a) {
-            foreach ($this->combinations->values($rand, static fn() => true, 100) as $combination) {
+        foreach (($this->a)($rand, static fn() => true, 100) as $a) {
+            foreach (($this->combinations)($rand, static fn() => true, 100) as $combination) {
                 yield $combination->unwrap()->add($a);
             }
         }

--- a/src/Set/Either.php
+++ b/src/Set/Either.php
@@ -100,7 +100,7 @@ final class Either implements Implementation
     }
 
     #[\Override]
-    public function values(Random $random, \Closure $predicate): \Generator
+    public function values(Random $random, \Closure $predicate, int $size): \Generator
     {
         $iterations = 0;
         /** @var list<Implementation<T>|Implementation<U>|Implementation<V>> */
@@ -120,7 +120,9 @@ final class Either implements Implementation
             $setToChoose = $random->between(0, $count - 1);
 
             try {
-                $value = $sets[$setToChoose]->values($random, $predicate)->current();
+                $value = $sets[$setToChoose]
+                    ->values($random, $predicate, $size)
+                    ->current();
 
                 if (\is_null($value)) {
                     continue;

--- a/src/Set/Either.php
+++ b/src/Set/Either.php
@@ -81,8 +81,11 @@ final class Either implements Implementation
     }
 
     #[\Override]
-    public function values(Random $random, \Closure $predicate, int $size): \Generator
-    {
+    public function __invoke(
+        Random $random,
+        \Closure $predicate,
+        int $size,
+    ): \Generator {
         $iterations = 0;
         /** @var list<Implementation<T>|Implementation<U>|Implementation<V>> */
         $sets = [$this->first, $this->second, ...$this->rest];
@@ -101,8 +104,7 @@ final class Either implements Implementation
             $setToChoose = $random->between(0, $count - 1);
 
             try {
-                $value = $sets[$setToChoose]
-                    ->values($random, $predicate, $size)
+                $value = $sets[$setToChoose]($random, $predicate, $size)
                     ->current();
 
                 if (\is_null($value)) {

--- a/src/Set/Either.php
+++ b/src/Set/Either.php
@@ -24,13 +24,11 @@ final class Either implements Implementation
      * @param Implementation<T> $first
      * @param Implementation<U> $second
      * @param list<Implementation<V>> $rest
-     * @param int<1, max> $size
      */
     private function __construct(
         private Implementation $first,
         private Implementation $second,
         private array $rest,
-        private int $size,
     ) {
     }
 
@@ -55,7 +53,7 @@ final class Either implements Implementation
         Implementation $second,
         Implementation ...$rest,
     ): self {
-        return new self($first, $second, $rest, 100);
+        return new self($first, $second, $rest);
     }
 
     /**
@@ -82,23 +80,6 @@ final class Either implements Implementation
         return Set::either($first, $second, ...$rest);
     }
 
-    /**
-     * @psalm-mutation-free
-     */
-    #[\Override]
-    public function take(int $size): self
-    {
-        return new self(
-            $this->first->take($size),
-            $this->second->take($size),
-            \array_map(
-                static fn(Implementation $set): Implementation => $set->take($size),
-                $this->rest,
-            ),
-            $size,
-        );
-    }
-
     #[\Override]
     public function values(Random $random, \Closure $predicate, int $size): \Generator
     {
@@ -106,7 +87,7 @@ final class Either implements Implementation
         /** @var list<Implementation<T>|Implementation<U>|Implementation<V>> */
         $sets = [$this->first, $this->second, ...$this->rest];
 
-        while ($iterations < $this->size) {
+        while ($iterations < $size) {
             $count = \count($sets);
 
             if ($count === 0 && $iterations === 0) {

--- a/src/Set/Elements.php
+++ b/src/Set/Elements.php
@@ -23,14 +23,12 @@ final class Elements implements Implementation
     /**
      * @psalm-mutation-free
      *
-     * @param int<1, max> $size
      * @param T $first
      * @param list<U> $elements
      */
     private function __construct(
         private mixed $first,
         private array $elements,
-        private int $size,
     ) {
     }
 
@@ -50,7 +48,7 @@ final class Elements implements Implementation
      */
     public static function implementation($first, ...$elements): self
     {
-        return new self($first, $elements, 100);
+        return new self($first, $elements);
     }
 
     /**
@@ -72,19 +70,6 @@ final class Elements implements Implementation
         return Set::of($first, ...$elements);
     }
 
-    /**
-     * @psalm-mutation-free
-     */
-    #[\Override]
-    public function take(int $size): self
-    {
-        return new self(
-            $this->first,
-            $this->elements,
-            $size,
-        );
-    }
-
     #[\Override]
     public function values(Random $random, \Closure $predicate, int $size): \Generator
     {
@@ -100,7 +85,7 @@ final class Elements implements Implementation
 
         $max = \count($elements) - 1;
 
-        while ($iterations < $this->size) {
+        while ($iterations < $size) {
             $index = $random->between(0, $max);
             /** @var mixed */
             $value = $elements[$index];

--- a/src/Set/Elements.php
+++ b/src/Set/Elements.php
@@ -71,8 +71,11 @@ final class Elements implements Implementation
     }
 
     #[\Override]
-    public function values(Random $random, \Closure $predicate, int $size): \Generator
-    {
+    public function __invoke(
+        Random $random,
+        \Closure $predicate,
+        int $size,
+    ): \Generator {
         $iterations = 0;
         $elements = \array_values(\array_filter(
             [$this->first, ...$this->elements],

--- a/src/Set/Elements.php
+++ b/src/Set/Elements.php
@@ -86,7 +86,7 @@ final class Elements implements Implementation
     }
 
     #[\Override]
-    public function values(Random $random, \Closure $predicate): \Generator
+    public function values(Random $random, \Closure $predicate, int $size): \Generator
     {
         $iterations = 0;
         $elements = \array_values(\array_filter(

--- a/src/Set/Elements.php
+++ b/src/Set/Elements.php
@@ -32,6 +32,34 @@ final class Elements implements Implementation
     ) {
     }
 
+    #[\Override]
+    public function __invoke(
+        Random $random,
+        \Closure $predicate,
+        int $size,
+    ): \Generator {
+        $iterations = 0;
+        $elements = \array_values(\array_filter(
+            [$this->first, ...$this->elements],
+            $predicate,
+        ));
+
+        if (\count($elements) === 0) {
+            throw new EmptySet;
+        }
+
+        $max = \count($elements) - 1;
+
+        while ($iterations < $size) {
+            $index = $random->between(0, $max);
+            /** @var mixed */
+            $value = $elements[$index];
+
+            yield Value::of($value)->predicatedOn($predicate);
+            ++$iterations;
+        }
+    }
+
     /**
      * @internal
      * @psalm-pure
@@ -68,33 +96,5 @@ final class Elements implements Implementation
     public static function of($first, ...$elements): Set
     {
         return Set::of($first, ...$elements);
-    }
-
-    #[\Override]
-    public function __invoke(
-        Random $random,
-        \Closure $predicate,
-        int $size,
-    ): \Generator {
-        $iterations = 0;
-        $elements = \array_values(\array_filter(
-            [$this->first, ...$this->elements],
-            $predicate,
-        ));
-
-        if (\count($elements) === 0) {
-            throw new EmptySet;
-        }
-
-        $max = \count($elements) - 1;
-
-        while ($iterations < $size) {
-            $index = $random->between(0, $max);
-            /** @var mixed */
-            $value = $elements[$index];
-
-            yield Value::of($value)->predicatedOn($predicate);
-            ++$iterations;
-        }
     }
 }

--- a/src/Set/Filter.php
+++ b/src/Set/Filter.php
@@ -56,18 +56,6 @@ final class Filter implements Implementation
         );
     }
 
-    /**
-     * @psalm-mutation-free
-     */
-    #[\Override]
-    public function take(int $size): self
-    {
-        return new self(
-            $this->set->take($size),
-            $this->predicate,
-        );
-    }
-
     #[\Override]
     public function values(Random $random, \Closure $predicate, int $size): \Generator
     {

--- a/src/Set/Filter.php
+++ b/src/Set/Filter.php
@@ -24,6 +24,21 @@ final class Filter implements Implementation
     ) {
     }
 
+    #[\Override]
+    public function __invoke(
+        Random $random,
+        \Closure $predicate,
+        int $size,
+    ): \Generator {
+        $own = $this->predicate;
+
+        yield from ($this->set)(
+            $random,
+            static fn($value) => /** @var I $value */ $own($value) && $predicate($value),
+            $size,
+        );
+    }
+
     /**
      * @internal
      * @psalm-pure
@@ -53,21 +68,6 @@ final class Filter implements Implementation
         return new self(
             $set,
             \Closure::fromCallable($predicate),
-        );
-    }
-
-    #[\Override]
-    public function __invoke(
-        Random $random,
-        \Closure $predicate,
-        int $size,
-    ): \Generator {
-        $own = $this->predicate;
-
-        yield from ($this->set)(
-            $random,
-            static fn($value) => /** @var I $value */ $own($value) && $predicate($value),
-            $size,
         );
     }
 }

--- a/src/Set/Filter.php
+++ b/src/Set/Filter.php
@@ -69,13 +69,14 @@ final class Filter implements Implementation
     }
 
     #[\Override]
-    public function values(Random $random, \Closure $predicate): \Generator
+    public function values(Random $random, \Closure $predicate, int $size): \Generator
     {
         $own = $this->predicate;
 
         yield from $this->set->values(
             $random,
             static fn($value) => /** @var I $value */ $own($value) && $predicate($value),
+            $size,
         );
     }
 }

--- a/src/Set/Filter.php
+++ b/src/Set/Filter.php
@@ -57,11 +57,14 @@ final class Filter implements Implementation
     }
 
     #[\Override]
-    public function values(Random $random, \Closure $predicate, int $size): \Generator
-    {
+    public function __invoke(
+        Random $random,
+        \Closure $predicate,
+        int $size,
+    ): \Generator {
         $own = $this->predicate;
 
-        yield from $this->set->values(
+        yield from ($this->set)(
             $random,
             static fn($value) => /** @var I $value */ $own($value) && $predicate($value),
             $size,

--- a/src/Set/FlatMap.php
+++ b/src/Set/FlatMap.php
@@ -28,25 +28,6 @@ final class FlatMap implements Implementation
     ) {
     }
 
-    /**
-     * @internal
-     * @psalm-pure
-     *
-     * @template T
-     * @template V
-     *
-     * @param callable(Seed<V>): Implementation<T> $decorate It must be a pure function (no randomness, no side effects)
-     * @param Implementation<V> $set
-     *
-     * @return self<T,V>
-     */
-    public static function implementation(
-        callable $decorate,
-        Implementation $set,
-    ): self {
-        return new self(\Closure::fromCallable($decorate), $set);
-    }
-
     #[\Override]
     public function __invoke(Random $random, \Closure $predicate, int $size): \Generator
     {
@@ -67,5 +48,24 @@ final class FlatMap implements Implementation
                 }
             }
         }
+    }
+
+    /**
+     * @internal
+     * @psalm-pure
+     *
+     * @template T
+     * @template V
+     *
+     * @param callable(Seed<V>): Implementation<T> $decorate It must be a pure function (no randomness, no side effects)
+     * @param Implementation<V> $set
+     *
+     * @return self<T,V>
+     */
+    public static function implementation(
+        callable $decorate,
+        Implementation $set,
+    ): self {
+        return new self(\Closure::fromCallable($decorate), $set);
     }
 }

--- a/src/Set/FlatMap.php
+++ b/src/Set/FlatMap.php
@@ -65,17 +65,17 @@ final class FlatMap implements Implementation
     }
 
     #[\Override]
-    public function values(Random $random, \Closure $predicate): \Generator
+    public function values(Random $random, \Closure $predicate, int $size): \Generator
     {
         $iterations = 0;
 
         // By default we favor reusing the same seed to generate multiple values
         // from the underlying set. To generate a more wide range of seeds one
         // can use the ->randomize() method.
-        foreach ($this->set->values($random, static fn() => true) as $seed) {
+        foreach ($this->set->values($random, static fn() => true, $size) as $seed) {
             $set = ($this->decorate)(Seed::of($seed));
 
-            foreach ($set->values($random, $predicate) as $value) {
+            foreach ($set->values($random, $predicate, $size) as $value) {
                 yield $value;
                 ++$iterations;
 

--- a/src/Set/FlatMap.php
+++ b/src/Set/FlatMap.php
@@ -48,17 +48,17 @@ final class FlatMap implements Implementation
     }
 
     #[\Override]
-    public function values(Random $random, \Closure $predicate, int $size): \Generator
+    public function __invoke(Random $random, \Closure $predicate, int $size): \Generator
     {
         $iterations = 0;
 
         // By default we favor reusing the same seed to generate multiple values
         // from the underlying set. To generate a more wide range of seeds one
         // can use the ->randomize() method.
-        foreach ($this->set->values($random, static fn() => true, $size) as $seed) {
+        foreach (($this->set)($random, static fn() => true, $size) as $seed) {
             $set = ($this->decorate)(Seed::of($seed));
 
-            foreach ($set->values($random, $predicate, $size) as $value) {
+            foreach ($set($random, $predicate, $size) as $value) {
                 yield $value;
                 ++$iterations;
 

--- a/src/Set/FlatMap.php
+++ b/src/Set/FlatMap.php
@@ -25,7 +25,6 @@ final class FlatMap implements Implementation
     private function __construct(
         private \Closure $decorate,
         private Implementation $set,
-        private int $size,
     ) {
     }
 
@@ -45,23 +44,7 @@ final class FlatMap implements Implementation
         callable $decorate,
         Implementation $set,
     ): self {
-        return new self(\Closure::fromCallable($decorate), $set, 100);
-    }
-
-    /**
-     * @psalm-mutation-free
-     */
-    #[\Override]
-    public function take(int $size): self
-    {
-        $decorate = $this->decorate;
-
-        /** @psalm-suppress MixedArgument */
-        return new self(
-            static fn($value) => $decorate($value)->take($size),
-            $this->set->take($size),
-            $size,
-        );
+        return new self(\Closure::fromCallable($decorate), $set);
     }
 
     #[\Override]
@@ -79,7 +62,7 @@ final class FlatMap implements Implementation
                 yield $value;
                 ++$iterations;
 
-                if ($iterations === $this->size) {
+                if ($iterations === $size) {
                     return;
                 }
             }

--- a/src/Set/FromGenerator.php
+++ b/src/Set/FromGenerator.php
@@ -94,7 +94,7 @@ final class FromGenerator implements Implementation
     }
 
     #[\Override]
-    public function values(Random $random, \Closure $predicate): \Generator
+    public function values(Random $random, \Closure $predicate, int $size): \Generator
     {
         $generator = ($this->generatorFactory)($random);
         $iterations = 0;

--- a/src/Set/FromGenerator.php
+++ b/src/Set/FromGenerator.php
@@ -78,8 +78,11 @@ final class FromGenerator implements Implementation
     }
 
     #[\Override]
-    public function values(Random $random, \Closure $predicate, int $size): \Generator
-    {
+    public function __invoke(
+        Random $random,
+        \Closure $predicate,
+        int $size,
+    ): \Generator {
         $generator = ($this->generatorFactory)($random);
         $iterations = 0;
 

--- a/src/Set/FromGenerator.php
+++ b/src/Set/FromGenerator.php
@@ -20,11 +20,9 @@ final class FromGenerator implements Implementation
      * @psalm-mutation-free
      *
      * @param \Closure(Random): \Generator<T|Seed<T>> $generatorFactory
-     * @param int<1, max> $size
      */
     private function __construct(
         private \Closure $generatorFactory,
-        private int $size,
         private bool $immutable,
     ) {
     }
@@ -45,7 +43,6 @@ final class FromGenerator implements Implementation
     ): self {
         return new self(
             \Closure::fromCallable($generatorFactory),
-            100,
             $immutable,
         );
     }
@@ -80,26 +77,13 @@ final class FromGenerator implements Implementation
             ->toSet();
     }
 
-    /**
-     * @psalm-mutation-free
-     */
-    #[\Override]
-    public function take(int $size): self
-    {
-        return new self(
-            $this->generatorFactory,
-            $size,
-            $this->immutable,
-        );
-    }
-
     #[\Override]
     public function values(Random $random, \Closure $predicate, int $size): \Generator
     {
         $generator = ($this->generatorFactory)($random);
         $iterations = 0;
 
-        while ($iterations < $this->size && $generator->valid()) {
+        while ($iterations < $size && $generator->valid()) {
             /** @var T|Seed<T> */
             $value = $generator->current();
             $value = Value::of($value)

--- a/src/Set/Implementation.php
+++ b/src/Set/Implementation.php
@@ -15,15 +15,6 @@ use Innmind\BlackBox\{
 interface Implementation
 {
     /**
-     * @psalm-mutation-free
-     *
-     * @param positive-int $size
-     *
-     * @return self<T>
-     */
-    public function take(int $size): self;
-
-    /**
      * @psalm-suppress InvalidTemplateParam
      *
      * @param \Closure(T): bool $predicate

--- a/src/Set/Implementation.php
+++ b/src/Set/Implementation.php
@@ -27,10 +27,15 @@ interface Implementation
      * @psalm-suppress InvalidTemplateParam
      *
      * @param \Closure(T): bool $predicate
+     * @param int<1, max> $size
      *
      * @throws EmptySet When no value can be generated
      *
      * @return \Generator<Value<T>>
      */
-    public function values(Random $random, \Closure $predicate): \Generator;
+    public function values(
+        Random $random,
+        \Closure $predicate,
+        int $size,
+    ): \Generator;
 }

--- a/src/Set/Implementation.php
+++ b/src/Set/Implementation.php
@@ -24,7 +24,7 @@ interface Implementation
      *
      * @return \Generator<Value<T>>
      */
-    public function values(
+    public function __invoke(
         Random $random,
         \Closure $predicate,
         int $size,

--- a/src/Set/Integers.php
+++ b/src/Set/Integers.php
@@ -111,7 +111,7 @@ final class Integers implements Implementation
     }
 
     #[\Override]
-    public function values(Random $random, \Closure $predicate): \Generator
+    public function values(Random $random, \Closure $predicate, int $size): \Generator
     {
         $min = $this->min;
         $max = $this->max;

--- a/src/Set/Integers.php
+++ b/src/Set/Integers.php
@@ -16,13 +16,10 @@ final class Integers implements Implementation
 {
     /**
      * @psalm-mutation-free
-     *
-     * @param int<1, max> $size
      */
     private function __construct(
         private int $min,
         private int $max,
-        private int $size,
     ) {
     }
 
@@ -35,7 +32,6 @@ final class Integers implements Implementation
         return new self(
             $min ?? \PHP_INT_MIN,
             $max ?? \PHP_INT_MAX,
-            100,
         );
     }
 
@@ -97,19 +93,6 @@ final class Integers implements Implementation
         return $this->min;
     }
 
-    /**
-     * @psalm-mutation-free
-     */
-    #[\Override]
-    public function take(int $size): self
-    {
-        return new self(
-            $this->min,
-            $this->max,
-            $size,
-        );
-    }
-
     #[\Override]
     public function values(Random $random, \Closure $predicate, int $size): \Generator
     {
@@ -119,7 +102,7 @@ final class Integers implements Implementation
         $predicate = static fn(int $value): bool => $bounds($value) && $predicate($value);
         $iterations = 0;
 
-        while ($iterations < $this->size) {
+        while ($iterations < $size) {
             $value = $random->between($this->min, $this->max);
             $value = Value::of($value)
                 ->predicatedOn($predicate);

--- a/src/Set/Integers.php
+++ b/src/Set/Integers.php
@@ -94,8 +94,11 @@ final class Integers implements Implementation
     }
 
     #[\Override]
-    public function values(Random $random, \Closure $predicate, int $size): \Generator
-    {
+    public function __invoke(
+        Random $random,
+        \Closure $predicate,
+        int $size,
+    ): \Generator {
         $min = $this->min;
         $max = $this->max;
         $bounds = static fn(int $value): bool => $value >= $min && $value <= $max;

--- a/src/Set/Map.php
+++ b/src/Set/Map.php
@@ -73,7 +73,7 @@ final class Map implements Implementation
     }
 
     #[\Override]
-    public function values(Random $random, \Closure $predicate): \Generator
+    public function values(Random $random, \Closure $predicate, int $size): \Generator
     {
         $map = $this->map;
         $mappedPredicate = static function(mixed $value) use ($map, $predicate): bool {
@@ -88,7 +88,7 @@ final class Map implements Implementation
             return $predicate($mapped);
         };
 
-        foreach ($this->set->values($random, $mappedPredicate) as $value) {
+        foreach ($this->set->values($random, $mappedPredicate, $size) as $value) {
             $mutable = !($value->immutable() && $this->immutable);
 
             yield Value::of($value)

--- a/src/Set/Map.php
+++ b/src/Set/Map.php
@@ -59,19 +59,6 @@ final class Map implements Implementation
         );
     }
 
-    /**
-     * @psalm-mutation-free
-     */
-    #[\Override]
-    public function take(int $size): self
-    {
-        return new self(
-            $this->map,
-            $this->set->take($size),
-            $this->immutable,
-        );
-    }
-
     #[\Override]
     public function values(Random $random, \Closure $predicate, int $size): \Generator
     {

--- a/src/Set/Map.php
+++ b/src/Set/Map.php
@@ -60,8 +60,11 @@ final class Map implements Implementation
     }
 
     #[\Override]
-    public function values(Random $random, \Closure $predicate, int $size): \Generator
-    {
+    public function __invoke(
+        Random $random,
+        \Closure $predicate,
+        int $size,
+    ): \Generator {
         $map = $this->map;
         $mappedPredicate = static function(mixed $value) use ($map, $predicate): bool {
             /** @var I $value */
@@ -75,7 +78,7 @@ final class Map implements Implementation
             return $predicate($mapped);
         };
 
-        foreach ($this->set->values($random, $mappedPredicate, $size) as $value) {
+        foreach (($this->set)($random, $mappedPredicate, $size) as $value) {
             $mutable = !($value->immutable() && $this->immutable);
 
             yield Value::of($value)

--- a/src/Set/Map.php
+++ b/src/Set/Map.php
@@ -26,6 +26,37 @@ final class Map implements Implementation
     ) {
     }
 
+    #[\Override]
+    public function __invoke(
+        Random $random,
+        \Closure $predicate,
+        int $size,
+    ): \Generator {
+        $map = $this->map;
+        $mappedPredicate = static function(mixed $value) use ($map, $predicate): bool {
+            /** @var I $value */
+            $mapped = $map($value);
+
+            if ($mapped instanceof Seed) {
+                /** @var D */
+                $mapped = $mapped->unwrap();
+            }
+
+            return $predicate($mapped);
+        };
+
+        foreach (($this->set)($random, $mappedPredicate, $size) as $value) {
+            $mutable = !($value->immutable() && $this->immutable);
+
+            yield Value::of($value)
+                ->mutable($mutable)
+                ->map(static fn($value) => $value->unwrap())
+                ->map($this->map)
+                ->predicatedOn($predicate)
+                ->shrinkWith(Map\Shrinker::instance);
+        }
+    }
+
     /**
      * @internal
      * @psalm-pure
@@ -57,36 +88,5 @@ final class Map implements Implementation
             $set,
             $immutable,
         );
-    }
-
-    #[\Override]
-    public function __invoke(
-        Random $random,
-        \Closure $predicate,
-        int $size,
-    ): \Generator {
-        $map = $this->map;
-        $mappedPredicate = static function(mixed $value) use ($map, $predicate): bool {
-            /** @var I $value */
-            $mapped = $map($value);
-
-            if ($mapped instanceof Seed) {
-                /** @var D */
-                $mapped = $mapped->unwrap();
-            }
-
-            return $predicate($mapped);
-        };
-
-        foreach (($this->set)($random, $mappedPredicate, $size) as $value) {
-            $mutable = !($value->immutable() && $this->immutable);
-
-            yield Value::of($value)
-                ->mutable($mutable)
-                ->map(static fn($value) => $value->unwrap())
-                ->map($this->map)
-                ->predicatedOn($predicate)
-                ->shrinkWith(Map\Shrinker::instance);
-        }
     }
 }

--- a/src/Set/Randomize.php
+++ b/src/Set/Randomize.php
@@ -71,13 +71,13 @@ final class Randomize implements Implementation
     }
 
     #[\Override]
-    public function values(Random $random, \Closure $predicate): \Generator
+    public function values(Random $random, \Closure $predicate, int $size): \Generator
     {
         $iterations = 0;
 
         while ($iterations < $this->size) {
             try {
-                $value = $this->set->values($random, $predicate)->current();
+                $value = $this->set->values($random, $predicate, $this->size)->current();
             } catch (EmptySet $e) {
                 continue;
             }

--- a/src/Set/Randomize.php
+++ b/src/Set/Randomize.php
@@ -20,11 +20,9 @@ final class Randomize implements Implementation
      * @psalm-mutation-free
      *
      * @param Implementation<I> $set
-     * @param int<1, max> $size
      */
     private function __construct(
         private Implementation $set,
-        private int $size,
     ) {
     }
 
@@ -40,7 +38,7 @@ final class Randomize implements Implementation
      */
     public static function implementation(Implementation $set): self
     {
-        return new self($set, 100);
+        return new self($set);
     }
 
     /**
@@ -58,26 +56,17 @@ final class Randomize implements Implementation
         return Collapse::of($set)->randomize();
     }
 
-    /**
-     * @psalm-mutation-free
-     */
-    #[\Override]
-    public function take(int $size): self
-    {
-        return new self(
-            $this->set,
-            $size,
-        );
-    }
-
     #[\Override]
     public function values(Random $random, \Closure $predicate, int $size): \Generator
     {
         $iterations = 0;
 
-        while ($iterations < $this->size) {
+        while ($iterations < $size) {
             try {
-                $value = $this->set->values($random, $predicate, $this->size)->current();
+                $value = $this
+                    ->set
+                    ->values($random, $predicate, $size)
+                    ->current();
             } catch (EmptySet $e) {
                 continue;
             }

--- a/src/Set/Randomize.php
+++ b/src/Set/Randomize.php
@@ -26,6 +26,30 @@ final class Randomize implements Implementation
     ) {
     }
 
+    #[\Override]
+    public function __invoke(
+        Random $random,
+        \Closure $predicate,
+        int $size,
+    ): \Generator {
+        $iterations = 0;
+
+        while ($iterations < $size) {
+            try {
+                $value = ($this->set)($random, $predicate, $size)->current();
+            } catch (EmptySet $e) {
+                continue;
+            }
+
+            if (\is_null($value)) {
+                continue;
+            }
+
+            yield $value;
+            ++$iterations;
+        }
+    }
+
     /**
      * @internal
      * @psalm-pure
@@ -54,29 +78,5 @@ final class Randomize implements Implementation
     public static function of(Set|Provider $set): Set
     {
         return Collapse::of($set)->randomize();
-    }
-
-    #[\Override]
-    public function __invoke(
-        Random $random,
-        \Closure $predicate,
-        int $size,
-    ): \Generator {
-        $iterations = 0;
-
-        while ($iterations < $size) {
-            try {
-                $value = ($this->set)($random, $predicate, $size)->current();
-            } catch (EmptySet $e) {
-                continue;
-            }
-
-            if (\is_null($value)) {
-                continue;
-            }
-
-            yield $value;
-            ++$iterations;
-        }
     }
 }

--- a/src/Set/Randomize.php
+++ b/src/Set/Randomize.php
@@ -57,16 +57,16 @@ final class Randomize implements Implementation
     }
 
     #[\Override]
-    public function values(Random $random, \Closure $predicate, int $size): \Generator
-    {
+    public function __invoke(
+        Random $random,
+        \Closure $predicate,
+        int $size,
+    ): \Generator {
         $iterations = 0;
 
         while ($iterations < $size) {
             try {
-                $value = $this
-                    ->set
-                    ->values($random, $predicate, $size)
-                    ->current();
+                $value = ($this->set)($random, $predicate, $size)->current();
             } catch (EmptySet $e) {
                 continue;
             }

--- a/src/Set/RealNumbers.php
+++ b/src/Set/RealNumbers.php
@@ -86,8 +86,11 @@ final class RealNumbers implements Implementation
     }
 
     #[\Override]
-    public function values(Random $random, \Closure $predicate, int $size): \Generator
-    {
+    public function __invoke(
+        Random $random,
+        \Closure $predicate,
+        int $size,
+    ): \Generator {
         $min = $this->min;
         $max = $this->max;
         $bounds = static fn(float $value): bool => $value >= $min && $value <= $max;

--- a/src/Set/RealNumbers.php
+++ b/src/Set/RealNumbers.php
@@ -16,13 +16,10 @@ final class RealNumbers implements Implementation
 {
     /**
      * @psalm-mutation-free
-     *
-     * @param int<1, max> $size
      */
     private function __construct(
         private int $min,
         private int $max,
-        private int $size,
     ) {
     }
 
@@ -35,7 +32,6 @@ final class RealNumbers implements Implementation
         return new self(
             $min ?? \PHP_INT_MIN,
             $max ?? \PHP_INT_MAX,
-            100,
         );
     }
 
@@ -89,19 +85,6 @@ final class RealNumbers implements Implementation
             ->toSet();
     }
 
-    /**
-     * @psalm-mutation-free
-     */
-    #[\Override]
-    public function take(int $size): self
-    {
-        return new self(
-            $this->min,
-            $this->max,
-            $size,
-        );
-    }
-
     #[\Override]
     public function values(Random $random, \Closure $predicate, int $size): \Generator
     {
@@ -111,7 +94,7 @@ final class RealNumbers implements Implementation
         $predicate = static fn(float $value): bool => $bounds($value) && $predicate($value);
         $iterations = 0;
 
-        while ($iterations < $this->size) {
+        while ($iterations < $size) {
             // simulate the function lcg_value()
             $lcg = ($random->between(0, 100) / 100);
             /** @psalm-suppress InvalidOperand Don't know why it complains */

--- a/src/Set/RealNumbers.php
+++ b/src/Set/RealNumbers.php
@@ -103,7 +103,7 @@ final class RealNumbers implements Implementation
     }
 
     #[\Override]
-    public function values(Random $random, \Closure $predicate): \Generator
+    public function values(Random $random, \Closure $predicate, int $size): \Generator
     {
         $min = $this->min;
         $max = $this->max;

--- a/src/Set/Sequence.php
+++ b/src/Set/Sequence.php
@@ -19,13 +19,11 @@ final class Sequence implements Implementation
      * @psalm-mutation-free
      *
      * @param Implementation<I> $set
-     * @param int<1, max> $size
      * @param int<1, max> $min
      */
     private function __construct(
         private Implementation $set,
         private Integers $sizes,
-        private int $size,
         private int $min,
     ) {
     }
@@ -48,7 +46,6 @@ final class Sequence implements Implementation
         return new self(
             $set,
             $sizes,
-            100,
             $sizes->min(),
         );
     }
@@ -68,20 +65,6 @@ final class Sequence implements Implementation
         return Set::sequence($set);
     }
 
-    /**
-     * @psalm-mutation-free
-     */
-    #[\Override]
-    public function take(int $size): self
-    {
-        return new self(
-            $this->set,
-            $this->sizes->take($size),
-            $size,
-            $this->min,
-        );
-    }
-
     #[\Override]
     public function values(Random $random, \Closure $predicate, int $size): \Generator
     {
@@ -99,7 +82,7 @@ final class Sequence implements Implementation
 
         do {
             foreach ($this->sizes->values($random, static fn() => true, $size) as $nextSize) {
-                if ($yielded === $this->size) {
+                if ($yielded === $size) {
                     return;
                 }
 
@@ -118,7 +101,7 @@ final class Sequence implements Implementation
 
                 ++$yielded;
             }
-        } while ($yielded < $this->size);
+        } while ($yielded < $size);
     }
 
     /**
@@ -132,7 +115,7 @@ final class Sequence implements Implementation
             return [];
         }
 
-        return \array_values(\iterator_to_array($this->set->take($size)->values(
+        return \array_values(\iterator_to_array($this->set->values(
             $rand,
             static fn() => true,
             $size,

--- a/src/Set/Sequence.php
+++ b/src/Set/Sequence.php
@@ -66,22 +66,23 @@ final class Sequence implements Implementation
     }
 
     #[\Override]
-    public function values(Random $random, \Closure $predicate, int $size): \Generator
-    {
+    public function __invoke(
+        Random $random,
+        \Closure $predicate,
+        int $size,
+    ): \Generator {
         $shrinker = new Sequence\Shrinker;
         $detonate = new Sequence\Detonate;
         $min = $this->min;
         $bounds = static fn(array $sequence): bool => \count($sequence) >= $min;
         $predicate = static fn(array $sequence): bool => /** @var list<I> $sequence */ $bounds($sequence) && $predicate($sequence);
-        $immutable = $this
-            ->set
-            ->values($random, static fn() => true, 1)
+        $immutable = ($this->set)($random, static fn() => true, 1)
             ->current()
             ?->immutable() ?? false;
         $yielded = 0;
 
         do {
-            foreach ($this->sizes->values($random, static fn() => true, $size) as $nextSize) {
+            foreach (($this->sizes)($random, static fn() => true, $size) as $nextSize) {
                 if ($yielded === $size) {
                     return;
                 }
@@ -115,7 +116,7 @@ final class Sequence implements Implementation
             return [];
         }
 
-        return \array_values(\iterator_to_array($this->set->values(
+        return \array_values(\iterator_to_array(($this->set)(
             $rand,
             static fn() => true,
             $size,

--- a/src/Set/Sequence.php
+++ b/src/Set/Sequence.php
@@ -28,43 +28,6 @@ final class Sequence implements Implementation
     ) {
     }
 
-    /**
-     * @internal
-     * @psalm-pure
-     *
-     * @template U
-     *
-     * @param Implementation<U> $set
-     *
-     * @return self<U>
-     */
-    public static function implementation(
-        Implementation $set,
-        Integers $sizes,
-    ): self {
-        /** @psalm-suppress ArgumentTypeCoercion */
-        return new self(
-            $set,
-            $sizes,
-            $sizes->min(),
-        );
-    }
-
-    /**
-     * @deprecated Use Set::sequence() instead
-     * @psalm-pure
-     *
-     * @template U
-     *
-     * @param Set<U>|Provider<U> $set
-     *
-     * @return Provider\Sequence<U>
-     */
-    public static function of(Set|Provider $set): Provider\Sequence
-    {
-        return Set::sequence($set);
-    }
-
     #[\Override]
     public function __invoke(
         Random $random,
@@ -103,6 +66,43 @@ final class Sequence implements Implementation
                 ++$yielded;
             }
         } while ($yielded < $size);
+    }
+
+    /**
+     * @internal
+     * @psalm-pure
+     *
+     * @template U
+     *
+     * @param Implementation<U> $set
+     *
+     * @return self<U>
+     */
+    public static function implementation(
+        Implementation $set,
+        Integers $sizes,
+    ): self {
+        /** @psalm-suppress ArgumentTypeCoercion */
+        return new self(
+            $set,
+            $sizes,
+            $sizes->min(),
+        );
+    }
+
+    /**
+     * @deprecated Use Set::sequence() instead
+     * @psalm-pure
+     *
+     * @template U
+     *
+     * @param Set<U>|Provider<U> $set
+     *
+     * @return Provider\Sequence<U>
+     */
+    public static function of(Set|Provider $set): Provider\Sequence
+    {
+        return Set::sequence($set);
     }
 
     /**

--- a/src/Set/Take.php
+++ b/src/Set/Take.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types = 1);
+
+namespace Innmind\BlackBox\Set;
+
+use Innmind\BlackBox\Random;
+
+/**
+ * @internal
+ * @template I
+ * @implements Implementation<I>
+ */
+final class Take implements Implementation
+{
+    /**
+     * @psalm-mutation-free
+     *
+     * @param Implementation<I> $set
+     * @param int<1, max> $size
+     */
+    private function __construct(
+        private Implementation $set,
+        private int $size,
+    ) {
+    }
+
+    /**
+     * @internal
+     * @psalm-pure
+     *
+     * @template T
+     *
+     * @param Implementation<T> $set
+     * @param int<1, max> $size
+     *
+     * @return self<T>
+     */
+    public static function implementation(
+        Implementation $set,
+        int $size,
+    ): self {
+        if ($set instanceof self) {
+            /** @psalm-suppress ImpurePropertyFetch */
+            if ($set->size < $size) {
+                return $set;
+            }
+
+            /** @psalm-suppress ImpurePropertyFetch */
+            $set = $set->set;
+        }
+
+        return new self($set->take($size), $size);
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    #[\Override]
+    public function take(int $size): self
+    {
+        return new self(
+            $this->set->take($size),
+            $size,
+        );
+    }
+
+    #[\Override]
+    public function values(Random $random, \Closure $predicate): \Generator
+    {
+        yield from $this->set->values(
+            $random,
+            $predicate,
+        );
+    }
+}

--- a/src/Set/Take.php
+++ b/src/Set/Take.php
@@ -65,11 +65,12 @@ final class Take implements Implementation
     }
 
     #[\Override]
-    public function values(Random $random, \Closure $predicate): \Generator
+    public function values(Random $random, \Closure $predicate, int $size): \Generator
     {
         yield from $this->set->values(
             $random,
             $predicate,
+            $this->size,
         );
     }
 }

--- a/src/Set/Take.php
+++ b/src/Set/Take.php
@@ -24,6 +24,19 @@ final class Take implements Implementation
     ) {
     }
 
+    #[\Override]
+    public function __invoke(
+        Random $random,
+        \Closure $predicate,
+        int $size,
+    ): \Generator {
+        yield from ($this->set)(
+            $random,
+            $predicate,
+            $this->size,
+        );
+    }
+
     /**
      * @internal
      * @psalm-pure
@@ -50,18 +63,5 @@ final class Take implements Implementation
         }
 
         return new self($set, $size);
-    }
-
-    #[\Override]
-    public function __invoke(
-        Random $random,
-        \Closure $predicate,
-        int $size,
-    ): \Generator {
-        yield from ($this->set)(
-            $random,
-            $predicate,
-            $this->size,
-        );
     }
 }

--- a/src/Set/Take.php
+++ b/src/Set/Take.php
@@ -53,9 +53,12 @@ final class Take implements Implementation
     }
 
     #[\Override]
-    public function values(Random $random, \Closure $predicate, int $size): \Generator
-    {
-        yield from $this->set->values(
+    public function __invoke(
+        Random $random,
+        \Closure $predicate,
+        int $size,
+    ): \Generator {
+        yield from ($this->set)(
             $random,
             $predicate,
             $this->size,

--- a/src/Set/Take.php
+++ b/src/Set/Take.php
@@ -49,19 +49,7 @@ final class Take implements Implementation
             $set = $set->set;
         }
 
-        return new self($set->take($size), $size);
-    }
-
-    /**
-     * @psalm-mutation-free
-     */
-    #[\Override]
-    public function take(int $size): self
-    {
-        return new self(
-            $this->set->take($size),
-            $size,
-        );
+        return new self($set, $size);
     }
 
     #[\Override]

--- a/src/Set/UnsafeStrings.php
+++ b/src/Set/UnsafeStrings.php
@@ -44,8 +44,11 @@ final class UnsafeStrings implements Implementation
     }
 
     #[\Override]
-    public function values(Random $random, \Closure $predicate, int $size): \Generator
-    {
+    public function __invoke(
+        Random $random,
+        \Closure $predicate,
+        int $size,
+    ): \Generator {
         $json = \file_get_contents(__DIR__.'/unsafeStrings.json');
 
         if ($json === false) {

--- a/src/Set/UnsafeStrings.php
+++ b/src/Set/UnsafeStrings.php
@@ -23,26 +23,6 @@ final class UnsafeStrings implements Implementation
     {
     }
 
-    /**
-     * @internal
-     * @psalm-pure
-     */
-    public static function implementation(): self
-    {
-        return new self;
-    }
-
-    /**
-     * @deprecated Use Set::strings()->unsafe() instead
-     * @psalm-pure
-     *
-     * @return Set<string>
-     */
-    public static function any(): Set
-    {
-        return Set::strings()->unsafe();
-    }
-
     #[\Override]
     public function __invoke(
         Random $random,
@@ -77,5 +57,25 @@ final class UnsafeStrings implements Implementation
             yield $value->shrinkWith(UnsafeStrings\Shrinker::instance);
             ++$iterations;
         }
+    }
+
+    /**
+     * @internal
+     * @psalm-pure
+     */
+    public static function implementation(): self
+    {
+        return new self;
+    }
+
+    /**
+     * @deprecated Use Set::strings()->unsafe() instead
+     * @psalm-pure
+     *
+     * @return Set<string>
+     */
+    public static function any(): Set
+    {
+        return Set::strings()->unsafe();
     }
 }

--- a/src/Set/UnsafeStrings.php
+++ b/src/Set/UnsafeStrings.php
@@ -55,7 +55,7 @@ final class UnsafeStrings implements Implementation
     }
 
     #[\Override]
-    public function values(Random $random, \Closure $predicate): \Generator
+    public function values(Random $random, \Closure $predicate, int $size): \Generator
     {
         $json = \file_get_contents(__DIR__.'/unsafeStrings.json');
 

--- a/src/Set/UnsafeStrings.php
+++ b/src/Set/UnsafeStrings.php
@@ -18,10 +18,8 @@ final class UnsafeStrings implements Implementation
 {
     /**
      * @psalm-mutation-free
-     *
-     * @param int<1, max> $size
      */
-    private function __construct(private int $size)
+    private function __construct()
     {
     }
 
@@ -31,7 +29,7 @@ final class UnsafeStrings implements Implementation
      */
     public static function implementation(): self
     {
-        return new self(100);
+        return new self;
     }
 
     /**
@@ -43,15 +41,6 @@ final class UnsafeStrings implements Implementation
     public static function any(): Set
     {
         return Set::strings()->unsafe();
-    }
-
-    /**
-     * @psalm-mutation-free
-     */
-    #[\Override]
-    public function take(int $size): self
-    {
-        return new self($size);
     }
 
     #[\Override]
@@ -74,11 +63,11 @@ final class UnsafeStrings implements Implementation
             throw new EmptySet;
         }
 
-        $size = \count($values) - 1;
+        $maxSize = \count($values) - 1;
         $iterations = 0;
 
-        while ($iterations < $this->size) {
-            $index = $random->between(0, $size);
+        while ($iterations < $size) {
+            $index = $random->between(0, $maxSize);
             $value = Value::of($values[$index])
                 ->predicatedOn($predicate);
 

--- a/tests/Set/ElementsTest.php
+++ b/tests/Set/ElementsTest.php
@@ -104,18 +104,6 @@ class ElementsTest extends TestCase
         $this->assertGreaterThan(1, $frequency['baz']);
     }
 
-    public function testTakeNoElement()
-    {
-        $this->assertCount(
-            0,
-            \iterator_to_array(
-                Elements::of(1, 2, 3)
-                    ->take(0)
-                    ->values(Random::mersenneTwister),
-            ),
-        );
-    }
-
     public function testThrowWhenCannotFindAValue()
     {
         $this->expectException(EmptySet::class);

--- a/tests/Set/IntegersTest.php
+++ b/tests/Set/IntegersTest.php
@@ -276,18 +276,6 @@ class IntegersTest extends TestCase
         }
     }
 
-    public function testTakeNoElement()
-    {
-        $this->assertCount(
-            0,
-            \iterator_to_array(
-                Integers::any()
-                    ->take(0)
-                    ->values(Random::mersenneTwister),
-            ),
-        );
-    }
-
     public function testStrategyAAlwaysLeadToSmallestValuePossible()
     {
         $ints = Integers::above(43);

--- a/tests/Set/RealNumbersTest.php
+++ b/tests/Set/RealNumbersTest.php
@@ -232,18 +232,6 @@ class RealNumbersTest extends TestCase
         }
     }
 
-    public function testTakeNoElement()
-    {
-        $this->assertCount(
-            0,
-            \iterator_to_array(
-                RealNumbers::any()
-                    ->take(0)
-                    ->values(Random::mersenneTwister),
-            ),
-        );
-    }
-
     public function testStrategyAAlwaysLeadToSmallestValuePossible()
     {
         $floats = RealNumbers::above(43);

--- a/tests/Set/StringsTest.php
+++ b/tests/Set/StringsTest.php
@@ -198,18 +198,6 @@ class StringsTest extends TestCase
         }
     }
 
-    public function testTakeNoElement()
-    {
-        $this->assertCount(
-            0,
-            \iterator_to_array(
-                Strings::any()
-                    ->take(0)
-                    ->values(Random::mersenneTwister),
-            ),
-        );
-    }
-
     public function testMadeOf()
     {
         $set = Strings::madeOf(Chars::lowercaseLetter());


### PR DESCRIPTION
Instead of having a method to specify the size on each set implementation, this adds a `Set\Take` that will hold the size that will be passed as argument to the underlying implementation when generating values.

This allows to have a similar design to `filter()` via `Set\Filter`.

Also this avoids having the default size, `100`, to be specified everywhere.