### PR TITLE
Improved PHPUnit bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `Innmind\BlackBox\PHPUnit\Compatibility::prove()`
+
 ## 6.1.0 - 2025-03-22
 
 ### Added

--- a/documentation/phpunit.md
+++ b/documentation/phpunit.md
@@ -137,6 +137,47 @@ If you want to take a look at a migration you can look at [BlackBox's own PHPUni
 !!! success ""
     Running BlackBox's PHPUnit tests via BlackBox increase execution speed by 35% (from ~7.1s down to ~4.6s) on a MackBook Pro M1 Max.
 
+### Display all scenarii
+
+If you've declared your [proofs inside a PHPUnit test method](#like-blackbox), when run directly via BlackBox it will show up as a single scenario. On top of that you can't see the [shrinking mechanism](preface/terminology.md#shrinking).
+
+You can better integrate these proofs inside BlackBox via these changes:
+
+```php title="MyTestCase.php" hl_lines="11 13 18"
+use Innmind\BlackBox\{
+    PHPUnit\BlackBox,
+    Set,
+};
+use PHPUnit\Framework\TestCase;
+
+final class MyTestCase extends TestCase
+{
+    use BlackBox;
+
+    public function testAddIsCommutative(int $a, int $b): BlackBox\Proof
+    {
+        return $this
+            ->forAll(
+                Set::integers(),
+                Set::integers(),
+            )
+            ->prove(function(int $a, int $b) {
+                $this->assertSame(
+                    add($a, $b),
+                    add($b, $a),
+                );
+            });
+    }
+}
+```
+
+Instead of calling `#!php $this->forAll()->then()` you call `#!php $this->forAll()->prove()` and return the object.
+
+Now each scenario will be correctly displayed and the number of scenarii configured in `Innmind\BlackBox\Application` is correctly respected (no need to use the `BLACKBOX_SET_SIZE` environment variable anymore).
+
+??? note
+    Note that the calls to `#!php ->take()` and `#!php ->disableShrinking()` won't do anything in this context as it uses the global configuration.
+
 ### Feature coverage
 
 PHPUnit is a very large testing framework with lots of features. BlackBox doesn't support all its features when running your tests.

--- a/src/PHPUnit/BlackBox/Proof.php
+++ b/src/PHPUnit/BlackBox/Proof.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types = 1);
+
+namespace Innmind\BlackBox\PHPUnit\BlackBox;
+
+use Innmind\BlackBox\Runner\Given;
+
+final class Proof
+{
+    /**
+     * @param \Closure(...mixed): void $test
+     */
+    private function __construct(
+        private Given $given,
+        private \Closure $test,
+    ) {
+    }
+
+    /**
+     * @internal
+     *
+     * @param callable(...mixed): void $test
+     */
+    public static function of(Given $given, callable $test): self
+    {
+        return new self($given, \Closure::fromCallable($test));
+    }
+
+    /**
+     * @internal
+     */
+    public function given(): Given
+    {
+        return $this->given;
+    }
+
+    /**
+     * @internal
+     *
+     * @return \Closure(...mixed): void
+     */
+    public function test(): \Closure
+    {
+        return $this->test;
+    }
+}

--- a/src/PHPUnit/Framework/TestCase.php
+++ b/src/PHPUnit/Framework/TestCase.php
@@ -34,14 +34,15 @@ abstract class TestCase
     /**
      * @internal
      *
+     * @param callable(...mixed): void $test
      * @param list<mixed> $args
      */
-    final public function executeTest(string $method, array $args): void
+    final public function executeClosure(callable $test, array $args): void
     {
         $this->setUp();
 
         try {
-            $this->$method(...$args);
+            $test(...$args);
             $this->tearDown();
         } catch (Assert\Failure|Scenario\Failure $e) {
             throw $e;
@@ -71,6 +72,21 @@ abstract class TestCase
                 );
             }
         }
+    }
+
+    /**
+     * @internal
+     *
+     * @param list<mixed> $args
+     */
+    final public function executeTest(string $method, array $args): void
+    {
+        $this->executeClosure(
+            function(...$args) use ($method): void {
+                $this->$method(...$args);
+            },
+            $args,
+        );
     }
 
     final public function assert(): Assert

--- a/src/PHPUnit/Proof/Bridge.php
+++ b/src/PHPUnit/Proof/Bridge.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types = 1);
+
+namespace Innmind\BlackBox\PHPUnit\Proof;
+
+use Innmind\BlackBox\{
+    PHPUnit\Framework\TestCase,
+    Runner\Assert,
+    Runner\Proof\Scenario as ScenarioInterface,
+    Runner\Proof\Scenario\Failure,
+};
+
+/**
+ * @internal
+ */
+final class Bridge implements ScenarioInterface
+{
+    /**
+     * @param \Closure(...mixed): void $test
+     * @param list<mixed> $args
+     */
+    private function __construct(
+        private \Closure $test,
+        private array $args,
+    ) {
+    }
+
+    #[\Override]
+    public function __invoke(Assert $assert): mixed
+    {
+        $refl = new \ReflectionProperty(TestCase::class, 'assert');
+        $refl->setValue(null, $assert);
+
+        try {
+            ($this->test)(...$this->args);
+        } catch (Failure|Assert\Failure $e) {
+            throw $e;
+        } catch (\Throwable $e) {
+            $assert->not()->throws(static function() use ($e) {
+                throw $e;
+            });
+        }
+
+        return null;
+    }
+
+    /**
+     * @internal
+     *
+     * @param \Closure(...mixed): void $test
+     * @param list<mixed> $args
+     */
+    public static function of(\Closure $test, array $args): self
+    {
+        return new self($test, $args);
+    }
+}

--- a/tests/Set/DichotomyTest.php
+++ b/tests/Set/DichotomyTest.php
@@ -15,9 +15,9 @@ class DichotomyTest extends TestCase
 {
     use BlackBox;
 
-    public function testInterface()
+    public function testInterface(): BlackBox\Proof
     {
-        $this
+        return $this
             ->forAll(
                 Set\Either::any(
                     Set\Integers::any(),
@@ -28,7 +28,7 @@ class DichotomyTest extends TestCase
                     Set\Strings::any(),
                 ),
             )
-            ->then(function($a, $b) {
+            ->prove(function($a, $b) {
                 $expectedA = Value::of($a);
                 $expectedB = Value::of($b);
 


### PR DESCRIPTION
## Problem

It's already possible to run BlackBox inside PHPUnit bridge inside BlackBox. 

The problem with this approach is that all scenarii run inside the PHPUnit test method appear as a single scenario. For long running tests it's hard to know what's happening between taking a long time, failing and thus shrinking or just a hanging test.

## Solution

This PR allows to return the proof description and then let the BlackBox runner run it as a normal proof.

## Note

There's a bit of hacking around closures `$this` context in order to keep the same object when first creating the proof and then executing it.