### PR TITLE
Fix `Set::uuid()` that can only produce `100` values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- `Set::uuid()` could only produce at most `100` values even when more asked
+
 ## 6.3.0 - 2025-05-17
 
 ### Changed

--- a/src/Set.php
+++ b/src/Set.php
@@ -405,7 +405,7 @@ final class Set
             $part(12),
         )
             ->immutable()
-            ->take(100);
+            ->toSet();
     }
 
     /**


### PR DESCRIPTION
## Problem

When calling `Set::uuid()->take(1_000)` it will only produce `100` because internally there's a call to `->take(100)` that will prevent from producing more.

## Solution

The call to `->take(100)` has been removed. 

This is safe because there's still the default bound to `100`.