### PR TITLE
Add `Set::enumerate()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `Innmind\BlackBox\Set::enumerate()`
+
 ### Fixed
 
 - `Set::uuid()` could only produce at most `100` values even when more asked

--- a/proofs/set.php
+++ b/proofs/set.php
@@ -379,4 +379,45 @@ return static function() {
             }
         },
     )->tag(Tag::ci, Tag::local);
+
+    yield proof(
+        'Set->enumerate() returns 100 elements by default',
+        given($anySet),
+        static function($assert, $set) {
+            $values = \iterator_to_array($set->enumerate());
+
+            $assert->count(100, $values);
+        },
+    )->tag(Tag::ci, Tag::local);
+
+    yield proof(
+        'Set->take()->enumerate() returns 100 elements by default',
+        given(
+            $anySet,
+            Set::integers()->between(1, 1_000),
+        ),
+        static function($assert, $set, $size) {
+            $values = \iterator_to_array($set->take($size)->enumerate());
+
+            $assert->count($size, $values);
+        },
+    )->tag(Tag::ci, Tag::local);
+
+    yield proof(
+        'Set->enumerate() contains the expressed type',
+        given(Set::of(
+            [[true, false], Set::of(true, false)],
+            [\range(0, 101), Set::integers()->between(0, 100)->toSet()],
+        )),
+        static function($assert, $pair) {
+            [$accepted, $set] = $pair;
+            $values = \iterator_to_array($set->enumerate());
+
+            foreach ($values as $value) {
+                $assert
+                    ->array($accepted)
+                    ->contains($value);
+            }
+        },
+    )->tag(Tag::ci, Tag::local);
 };

--- a/src/Set.php
+++ b/src/Set.php
@@ -523,6 +523,18 @@ final class Set
     }
 
     /**
+     * @throws EmptySet When no value can be generated
+     *
+     * @return iterable<T>
+     */
+    public function enumerate(): iterable
+    {
+        foreach ($this->values(Random::default) as $value) {
+            yield $value->unwrap();
+        }
+    }
+
+    /**
      * @internal End users mustn't use this method directly (BC breaks may be introduced)
      *
      * @throws EmptySet When no value can be generated


### PR DESCRIPTION
This offers an official API for people to get a random list of generated values without exposing the internal details of `Random` and the `Value` wrapper.

This also keep away the access to the shrinking mechanism (meaning we can still refactor this code if needed)