### PR TITLE
Add missing shortcuts on providers to return `Set`s

### DIFF
--- a/src/Runner/Proof/Properties.php
+++ b/src/Runner/Proof/Properties.php
@@ -84,7 +84,6 @@ final class Properties implements Proof
             $this->systemUnderTest,
         )
             ->immutable()
-            ->toSet()
             ->randomize()
             ->take($count);
     }

--- a/src/Runner/Proof/Property.php
+++ b/src/Runner/Proof/Property.php
@@ -108,7 +108,6 @@ final class Property implements Proof
             $this->systemUnderTest,
         )
             ->immutable()
-            ->toSet()
             ->randomize()
             ->take($count);
     }

--- a/src/Set/MadeOf.php
+++ b/src/Set/MadeOf.php
@@ -3,7 +3,10 @@ declare(strict_types = 1);
 
 namespace Innmind\BlackBox\Set;
 
-use Innmind\BlackBox\Set;
+use Innmind\BlackBox\{
+    Set,
+    Exception\EmptySet,
+};
 
 /**
  * @implements Provider<string>
@@ -130,6 +133,36 @@ final class MadeOf implements Provider
     public function flatMap(callable $map): Set
     {
         return $this->toSet()->flatMap($map);
+    }
+
+    /**
+     * @psalm-mutation-free
+     *
+     * @return Set<string>
+     */
+    public function randomize(): Set
+    {
+        return $this->toSet()->randomize();
+    }
+
+    /**
+     * @psalm-mutation-free
+     *
+     * @return Set<?string>
+     */
+    public function nullable(): Set
+    {
+        return $this->toSet()->nullable();
+    }
+
+    /**
+     * @throws EmptySet When no value can be generated
+     *
+     * @return iterable<string>
+     */
+    public function enumerate(): iterable
+    {
+        return $this->toSet()->enumerate();
     }
 
     /**

--- a/src/Set/Properties.php
+++ b/src/Set/Properties.php
@@ -7,6 +7,7 @@ use Innmind\BlackBox\{
     Set,
     Property as Concrete,
     Properties as Ensure,
+    Exception\EmptySet,
 };
 
 /**
@@ -106,6 +107,36 @@ final class Properties implements Provider
     public function flatMap(callable $map): Set
     {
         return $this->toSet()->flatMap($map);
+    }
+
+    /**
+     * @psalm-mutation-free
+     *
+     * @return Set<?Ensure>
+     */
+    public function nullable(): Set
+    {
+        return $this->toSet()->nullable();
+    }
+
+    /**
+     * @psalm-mutation-free
+     *
+     * @return Set<Ensure>
+     */
+    public function randomize(): Set
+    {
+        return $this->toSet()->randomize();
+    }
+
+    /**
+     * @throws EmptySet When no value can be generated
+     *
+     * @return iterable<Ensure>
+     */
+    public function enumerate(): iterable
+    {
+        return $this->toSet()->enumerate();
     }
 
     /**

--- a/src/Set/Provider/Composite.php
+++ b/src/Set/Provider/Composite.php
@@ -8,6 +8,7 @@ use Innmind\BlackBox\{
     Set\Provider,
     Set\Seed,
     Set\Implementation,
+    Exception\EmptySet,
 };
 
 /**
@@ -138,6 +139,36 @@ final class Composite implements Provider
     public function flatMap(callable $map): Set
     {
         return $this->toSet()->flatMap($map);
+    }
+
+    /**
+     * @psalm-mutation-free
+     *
+     * @return Set<T>
+     */
+    public function randomize(): Set
+    {
+        return $this->toSet()->randomize();
+    }
+
+    /**
+     * @psalm-mutation-free
+     *
+     * @return Set<?T>
+     */
+    public function nullable(): Set
+    {
+        return $this->toSet()->nullable();
+    }
+
+    /**
+     * @throws EmptySet When no value can be generated
+     *
+     * @return iterable<T>
+     */
+    public function enumerate(): iterable
+    {
+        return $this->toSet()->enumerate();
     }
 
     /**

--- a/src/Set/Provider/Generator.php
+++ b/src/Set/Provider/Generator.php
@@ -8,6 +8,7 @@ use Innmind\BlackBox\{
     Set\Provider,
     Set\Seed,
     Set\Implementation,
+    Exception\EmptySet,
     Random,
 };
 
@@ -127,6 +128,36 @@ final class Generator implements Provider
     public function flatMap(callable $map): Set
     {
         return $this->toSet()->flatMap($map);
+    }
+
+    /**
+     * @psalm-mutation-free
+     *
+     * @return Set<T>
+     */
+    public function randomize(): Set
+    {
+        return $this->toSet()->randomize();
+    }
+
+    /**
+     * @psalm-mutation-free
+     *
+     * @return Set<?T>
+     */
+    public function nullable(): Set
+    {
+        return $this->toSet()->nullable();
+    }
+
+    /**
+     * @throws EmptySet When no value can be generated
+     *
+     * @return iterable<T>
+     */
+    public function enumerate(): iterable
+    {
+        return $this->toSet()->enumerate();
     }
 
     /**

--- a/src/Set/Provider/Integers.php
+++ b/src/Set/Provider/Integers.php
@@ -8,6 +8,7 @@ use Innmind\BlackBox\{
     Set\Provider,
     Set\Seed,
     Set\Implementation,
+    Exception\EmptySet,
 };
 
 /**
@@ -150,6 +151,36 @@ final class Integers implements Provider
     public function flatMap(callable $map): Set
     {
         return $this->toSet()->flatMap($map);
+    }
+
+    /**
+     * @psalm-mutation-free
+     *
+     * @return Set<int>
+     */
+    public function randomize(): Set
+    {
+        return $this->toSet()->randomize();
+    }
+
+    /**
+     * @psalm-mutation-free
+     *
+     * @return Set<?int>
+     */
+    public function nullable(): Set
+    {
+        return $this->toSet()->nullable();
+    }
+
+    /**
+     * @throws EmptySet When no value can be generated
+     *
+     * @return iterable<int>
+     */
+    public function enumerate(): iterable
+    {
+        return $this->toSet()->enumerate();
     }
 
     /**

--- a/src/Set/Provider/RealNumbers.php
+++ b/src/Set/Provider/RealNumbers.php
@@ -8,6 +8,7 @@ use Innmind\BlackBox\{
     Set\Provider,
     Set\Seed,
     Set\Implementation,
+    Exception\EmptySet,
 };
 
 /**
@@ -112,6 +113,36 @@ final class RealNumbers implements Provider
     public function flatMap(callable $map): Set
     {
         return $this->toSet()->flatMap($map);
+    }
+
+    /**
+     * @psalm-mutation-free
+     *
+     * @return Set<float>
+     */
+    public function randomize(): Set
+    {
+        return $this->toSet()->randomize();
+    }
+
+    /**
+     * @psalm-mutation-free
+     *
+     * @return Set<?float>
+     */
+    public function nullable(): Set
+    {
+        return $this->toSet()->nullable();
+    }
+
+    /**
+     * @throws EmptySet When no value can be generated
+     *
+     * @return iterable<float>
+     */
+    public function enumerate(): iterable
+    {
+        return $this->toSet()->enumerate();
     }
 
     /**

--- a/src/Set/Provider/Sequence.php
+++ b/src/Set/Provider/Sequence.php
@@ -9,6 +9,7 @@ use Innmind\BlackBox\{
     Set\Seed,
     Set\Implementation,
     Set\Integers,
+    Exception\EmptySet,
 };
 
 /**
@@ -147,6 +148,36 @@ final class Sequence implements Provider
     public function flatMap(callable $map): Set
     {
         return $this->toSet()->flatMap($map);
+    }
+
+    /**
+     * @psalm-mutation-free
+     *
+     * @return Set<list<V>>
+     */
+    public function randomize(): Set
+    {
+        return $this->toSet()->randomize();
+    }
+
+    /**
+     * @psalm-mutation-free
+     *
+     * @return Set<?list<V>>
+     */
+    public function nullable(): Set
+    {
+        return $this->toSet()->nullable();
+    }
+
+    /**
+     * @throws EmptySet When no value can be generated
+     *
+     * @return iterable<list<V>>
+     */
+    public function enumerate(): iterable
+    {
+        return $this->toSet()->enumerate();
     }
 
     /**

--- a/src/Set/Provider/Strings.php
+++ b/src/Set/Provider/Strings.php
@@ -8,6 +8,7 @@ use Innmind\BlackBox\{
     Set\Provider,
     Set\Seed,
     Set\Implementation,
+    Exception\EmptySet,
 };
 
 /**
@@ -164,6 +165,36 @@ final class Strings implements Provider
     public function flatMap(callable $map): Set
     {
         return $this->toSet()->flatMap($map);
+    }
+
+    /**
+     * @psalm-mutation-free
+     *
+     * @return Set<string>
+     */
+    public function randomize(): Set
+    {
+        return $this->toSet()->randomize();
+    }
+
+    /**
+     * @psalm-mutation-free
+     *
+     * @return Set<?string>
+     */
+    public function nullable(): Set
+    {
+        return $this->toSet()->nullable();
+    }
+
+    /**
+     * @throws EmptySet When no value can be generated
+     *
+     * @return iterable<string>
+     */
+    public function enumerate(): iterable
+    {
+        return $this->toSet()->enumerate();
     }
 
     /**

--- a/src/Set/Provider/Strings/Chars.php
+++ b/src/Set/Provider/Strings/Chars.php
@@ -7,6 +7,7 @@ use Innmind\BlackBox\{
     Set,
     Set\Provider,
     Set\Seed,
+    Exception\EmptySet,
 };
 
 /**
@@ -142,6 +143,36 @@ final class Chars implements Provider
     public function flatMap(callable $map): Set
     {
         return $this->toSet()->flatMap($map);
+    }
+
+    /**
+     * @psalm-mutation-free
+     *
+     * @return Set<non-empty-string>
+     */
+    public function randomize(): Set
+    {
+        return $this->toSet()->randomize();
+    }
+
+    /**
+     * @psalm-mutation-free
+     *
+     * @return Set<?non-empty-string>
+     */
+    public function nullable(): Set
+    {
+        return $this->toSet()->nullable();
+    }
+
+    /**
+     * @throws EmptySet When no value can be generated
+     *
+     * @return iterable<non-empty-string>
+     */
+    public function enumerate(): iterable
+    {
+        return $this->toSet()->enumerate();
     }
 
     /**

--- a/src/Set/Provider/Strings/Unicode.php
+++ b/src/Set/Provider/Strings/Unicode.php
@@ -8,6 +8,7 @@ use Innmind\BlackBox\{
     Set\Provider,
     Set\Seed,
     Set\MadeOf,
+    Exception\EmptySet,
 };
 
 /**
@@ -55,6 +56,9 @@ final class Unicode implements Provider
                     'filter',
                     'map',
                     'flatMap',
+                    'randomize',
+                    'nullable',
+                    'enumerate',
                     'toSet',
                     'block',
                 ],
@@ -2912,6 +2916,36 @@ final class Unicode implements Provider
     public function flatMap(callable $map): Set
     {
         return $this->toSet()->flatMap($map);
+    }
+
+    /**
+     * @psalm-mutation-free
+     *
+     * @return Set<string>
+     */
+    public function randomize(): Set
+    {
+        return $this->toSet()->randomize();
+    }
+
+    /**
+     * @psalm-mutation-free
+     *
+     * @return Set<?string>
+     */
+    public function nullable(): Set
+    {
+        return $this->toSet()->nullable();
+    }
+
+    /**
+     * @throws EmptySet When no value can be generated
+     *
+     * @return iterable<string>
+     */
+    public function enumerate(): iterable
+    {
+        return $this->toSet()->enumerate();
     }
 
     /**

--- a/src/Set/Slice.php
+++ b/src/Set/Slice.php
@@ -6,6 +6,7 @@ namespace Innmind\BlackBox\Set;
 use Innmind\BlackBox\{
     Set,
     Util\Slice as Util,
+    Exception\EmptySet,
 };
 
 /**
@@ -117,6 +118,36 @@ final class Slice implements Provider
     public function flatMap(callable $map): Set
     {
         return $this->toSet()->flatMap($map);
+    }
+
+    /**
+     * @psalm-mutation-free
+     *
+     * @return Set<Util>
+     */
+    public function randomize(): Set
+    {
+        return $this->toSet()->randomize();
+    }
+
+    /**
+     * @psalm-mutation-free
+     *
+     * @return Set<?Util>
+     */
+    public function nullable(): Set
+    {
+        return $this->toSet()->nullable();
+    }
+
+    /**
+     * @throws EmptySet When no value can be generated
+     *
+     * @return iterable<Util>
+     */
+    public function enumerate(): iterable
+    {
+        return $this->toSet()->enumerate();
     }
 
     /**


### PR DESCRIPTION
This allows to avoid calling `->toSet()` on providers.