### PR TITLE
Fix displaying a failing scenario when coming from the PHPUnit bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Scenario values weren't displayed on failure when coming from the PHPUnit bridge
+
 ## 6.4.0 - 2025-05-23
 
 ### Added

--- a/src/PHPUnit/Proof/Bridge.php
+++ b/src/PHPUnit/Proof/Bridge.php
@@ -54,4 +54,34 @@ final class Bridge implements ScenarioInterface
     {
         return new self($test, $args);
     }
+
+    /**
+     * @return list<array{string, mixed}>
+     */
+    public function parameters(): array
+    {
+        $reflection = new \ReflectionFunction($this->test);
+        /**
+         * @psalm-suppress MixedArrayAccess
+         * @var \Closure
+         */
+        $innerTest = $reflection->getClosureUsedVariables()['test'];
+        $parameters = (new \ReflectionFunction($innerTest))->getParameters();
+
+        $parameters = \array_map(
+            static fn($parameter) => $parameter->getName(),
+            $parameters,
+        );
+        $args = [];
+
+        /** @var mixed $arg */
+        foreach ($this->args as $index => $arg) {
+            $args[] = [
+                $parameters[$index] ?? 'undefined',
+                $arg,
+            ];
+        }
+
+        return $args;
+    }
 }

--- a/src/Runner/Printer/Proof/Standard.php
+++ b/src/Runner/Printer/Proof/Standard.php
@@ -3,14 +3,15 @@ declare(strict_types = 1);
 
 namespace Innmind\BlackBox\Runner\Printer\Proof;
 
-use Innmind\BlackBox\Runner\{
-    Proof\Scenario\Failure,
-    Assert\Failure\Truth,
-    Assert\Failure\Property,
-    Assert\Failure\Comparison,
-    IO,
-    Printer\Proof,
-    Proof\Scenario,
+use Innmind\BlackBox\{
+    Runner\Proof\Scenario\Failure,
+    Runner\Assert\Failure\Truth,
+    Runner\Assert\Failure\Property,
+    Runner\Assert\Failure\Comparison,
+    Runner\IO,
+    Runner\Printer\Proof,
+    Runner\Proof\Scenario,
+    PHPUnit\Proof\Bridge,
 };
 use Symfony\Component\VarDumper\{
     Dumper\CliDumper,
@@ -201,7 +202,10 @@ final class Standard implements Proof
 
     private function renderScenario(IO $output, Scenario $scenario): void
     {
-        if ($scenario instanceof Scenario\Inline) {
+        if (
+            $scenario instanceof Scenario\Inline ||
+            $scenario instanceof Bridge
+        ) {
             $this->renderInlineScenario($output, $scenario);
         }
 
@@ -214,7 +218,7 @@ final class Standard implements Proof
         }
     }
 
-    private function renderInlineScenario(IO $output, Scenario\Inline $scenario): void
+    private function renderInlineScenario(IO $output, Scenario\Inline|Bridge $scenario): void
     {
         /** @var mixed $value */
         foreach ($scenario->parameters() as [$name, $value]) {


### PR DESCRIPTION
## Problem

#43 introduced a new bridge to better integrate PHPUnit in BlackBox. To do that it introduced a new `Scenario` implementation but didn't make the printer aware of it.

## Solution

Extract the list of parameters from the new bridge `Scenario` and display them.

## Note

In the future maybe it should introduce a new interface to make this transparent, and not make the printer directly aware of PHPUnit (as currently it will make #49 impossible to do). 