### PR TITLE
`Assert::fail()` `never` returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- `Innmind\BlackBox\Runner\Assert::fail()` now returns `never`
+
 ## 6.4.1 - 2025-05-25
 
 ### Fixed

--- a/src/Runner/Assert.php
+++ b/src/Runner/Assert.php
@@ -50,7 +50,7 @@ final class Assert
      *
      * @throws Failure
      */
-    public function fail(string $message): void
+    public function fail(string $message): never
     {
         throw Failure::of(Truth::of($message));
     }


### PR DESCRIPTION
This helps static analysis tools to understand the method throws an exception everytime.