### PR TITLE
Require PHP `8.4`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        php-version: ['8.2', '8.3', '8.4']
+        php-version: ['8.4', '8.5']
         dependency-versions: ['lowest', 'highest']
     name: 'PHPUnit'
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Requires PHP `8.4`
+
+### Removed
+
+- Support for `symfony/var-dumper` `~6.0|~7.0`
+- Support for `phpunit/phpunit` `~10.0|~11.0|~12.0`
+- Support for `phpunit/php-timer` `~6.0|~7.0|~8.0`
+- Support for `phpunit/php-code-coverage` `~10.0|~11.0|~12.0`
+
 ## 6.12.0 - 2026-04-11
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
         "issues": "http://github.com/Innmind/BlackBox/issues"
     },
     "require": {
-        "php": "~8.2",
-        "symfony/var-dumper": "~6.0|~7.0|~8.0",
-        "phpunit/phpunit": "~10.0|~11.0|~12.0|~13.0",
-        "phpunit/php-timer": "~6.0|~7.0|~8.0|~9.0",
-        "phpunit/php-code-coverage": "~10.1|~11.0|~12.0|~13.0|~14.0"
+        "php": "~8.4",
+        "symfony/var-dumper": "~8.0",
+        "phpunit/phpunit": "~13.0",
+        "phpunit/php-timer": "~9.0",
+        "phpunit/php-code-coverage": "~13.0|~14.0"
     },
     "autoload": {
         "psr-4": {
@@ -36,7 +36,7 @@
         }
     },
     "require-dev": {
-        "innmind/static-analysis": "^1.2.1",
+        "innmind/static-analysis": "~1.3",
         "ramsey/uuid": "^4.1",
         "innmind/coding-standard": "~2.0"
     }


### PR DESCRIPTION
It also removes support for dependencies with a minimum requirement below PHP `8.4`. 

This helps reduce the dependency matrix.