### PR TITLE
Only pass the `Prove` object when loading proof files

### DIFF
--- a/fixtures/proofs.php
+++ b/fixtures/proofs.php
@@ -22,7 +22,7 @@ use Fixtures\Innmind\BlackBox\{
     UpperBoundAtHundred,
 };
 
-return static function($load, $prove) {
+return static function($prove) {
     yield $prove
         ->property(
             DownAndUpIsAnIdentityFunction::class,

--- a/proofs/add.php
+++ b/proofs/add.php
@@ -11,7 +11,7 @@ function add($a, $b): string
     return \gmp_strval(\gmp_add($a, $b));
 }
 
-return static function($_, $prove) {
+return static function($prove) {
     yield $prove
         ->proof('add is commutative')
         ->given(

--- a/proofs/application.php
+++ b/proofs/application.php
@@ -21,7 +21,7 @@ use Fixtures\Innmind\BlackBox\{
     UpperBoundAtHundred,
 };
 
-return static function($load, $prove) {
+return static function($prove) {
     yield $prove
         ->proof('BlackBox can run with any of the random strategies')
         ->given(Set::of(...Random::cases()))

--- a/proofs/runner/assert.php
+++ b/proofs/runner/assert.php
@@ -11,7 +11,7 @@ use Innmind\BlackBox\{
     Tag,
 };
 
-return static function($load, $prove) {
+return static function($prove) {
     yield $prove
         ->proof('Assert->fail()')
         ->given(Set::strings())

--- a/proofs/runner/printer.php
+++ b/proofs/runner/printer.php
@@ -23,7 +23,7 @@ use Fixtures\Innmind\BlackBox\{
     LowerBoundAtZero,
 };
 
-return static function($load, $prove) {
+return static function($prove) {
     yield $prove
         ->test(
             'Printer->start()',

--- a/proofs/set.php
+++ b/proofs/set.php
@@ -7,7 +7,7 @@ use Innmind\BlackBox\{
     Tag,
 };
 
-return static function($load, $prove) {
+return static function($prove) {
     $anySet = Set::of(
         Set::integers()->toSet(),
         // real numbers not used as it may return the type integer

--- a/proofs/set/composite.php
+++ b/proofs/set/composite.php
@@ -9,7 +9,7 @@ use Innmind\BlackBox\{
     Tag,
 };
 
-return static function($load, $prove) {
+return static function($prove) {
     yield $prove
         ->test(
             'Test reduce Composite to the minimum values',

--- a/proofs/set/mutuallyExclusive.php
+++ b/proofs/set/mutuallyExclusive.php
@@ -6,7 +6,7 @@ use Innmind\BlackBox\{
     Tag,
 };
 
-return static function($load, $prove) {
+return static function($prove) {
     yield $prove
         ->proof('Set\MutuallyExclusive')
         ->given(Set\MutuallyExclusive::of(

--- a/proofs/set/sequence.php
+++ b/proofs/set/sequence.php
@@ -9,7 +9,7 @@ use Innmind\BlackBox\{
     Tag,
 };
 
-return static function($load, $prove) {
+return static function($prove) {
     yield $prove
         ->test(
             'Test reduce Sequence to the minimum values',

--- a/proofs/set/slice.php
+++ b/proofs/set/slice.php
@@ -6,7 +6,7 @@ use Innmind\BlackBox\{
     Tag,
 };
 
-return static function($load, $prove) {
+return static function($prove) {
     yield $prove
         ->proof('Set\Slice')
         ->given(

--- a/proofs/set/tuple.php
+++ b/proofs/set/tuple.php
@@ -7,7 +7,7 @@ use Innmind\BlackBox\{
     Tag,
 };
 
-return static function($load, $prove) {
+return static function($prove) {
     yield $prove
         ->proof('Set::tuple() values always contain the same number of elements as sets')
         ->given(

--- a/proofs/set/unsafeStrings.php
+++ b/proofs/set/unsafeStrings.php
@@ -7,7 +7,7 @@ use Innmind\BlackBox\{
     Tag,
 };
 
-return static function($load, $prove) {
+return static function($prove) {
     yield $prove
         ->test(
             'Set::strings()->unsafe() shrink to an empty string',

--- a/src/Runner/Load.php
+++ b/src/Runner/Load.php
@@ -16,14 +16,13 @@ final class Load
      *
      * @return \Generator<Proof>
      */
-    public function __invoke(string $path): \Generator
+    public function __invoke(Prove $prove, string $path): \Generator
     {
         /**
          * @psalm-suppress UnresolvableInclude Presume the developer uses a valid absolute path
          * @var mixed $value
-         * @todo switch $this in Prove in v7
          */
-        foreach ((require $path)($this, Prove::new()) as $value) {
+        foreach ((require $path)($prove) as $value) {
             if ($value instanceof Proof) {
                 yield $value;
             }
@@ -31,42 +30,42 @@ final class Load
     }
 
     /**
-     * @return \Closure(): \Generator<Proof>
+     * @return \Closure(Prove): \Generator<Proof>
      */
     #[\NoDiscard]
     public static function file(string $path): \Closure
     {
-        return static function() use ($path) {
-            yield from (new self)($path);
+        return static function(Prove $prove) use ($path) {
+            yield from (new self)($prove, $path);
         };
     }
 
     /**
-     * @return \Closure(): \Generator<Proof>
+     * @return \Closure(Prove): \Generator<Proof>
      */
     #[\NoDiscard]
     public static function directory(string $path): \Closure
     {
-        return static function() use ($path) {
+        return static function(Prove $prove) use ($path) {
             $load = new self;
             $files = new \FilesystemIterator($path);
 
             /** @var \SplFileInfo $file */
             foreach ($files as $path => $file) {
                 if ($file->isFile() && \is_string($path)) {
-                    yield from $load($path);
+                    yield from $load($prove, $path);
                 }
             }
         };
     }
 
     /**
-     * @return \Closure(): \Generator<Proof>
+     * @return \Closure(Prove): \Generator<Proof>
      */
     #[\NoDiscard]
     public static function everythingIn(string $path): \Closure
     {
-        return static function() use ($path) {
+        return static function(Prove $prove) use ($path) {
             $load = new self;
             $files = new \RecursiveIteratorIterator(
                 new \RecursiveDirectoryIterator($path),
@@ -78,7 +77,7 @@ final class Load
              */
             foreach ($files as $path => $file) {
                 if ($file->isFile()) {
-                    yield from $load($path);
+                    yield from $load($prove, $path);
                 }
             }
         };


### PR DESCRIPTION
This is to have the same API as the `Application::tryToProve()` argument.