### PR TITLE
Make PHPUnit an optional dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `Innmind\BlackBox\Runner\Proof` is now a final class
 - `Innmind\BlackBox\Runner\Proof` constructors are now flagged as internal
 - `Innmind\BlackBox\Runner\Proof::scenarii()` is now flagged as internal
+- PHPUnit attributes `Group` and `DataProvider` are now longer read when running tests with BlackBox, use the `Innmind\BlackBox\` prefixed ones instead
 
 ### Removed
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     "require": {
         "php": "~8.4",
         "symfony/var-dumper": "~8.0",
-        "phpunit/phpunit": "~13.0",
         "phpunit/php-timer": "~9.0",
         "phpunit/php-code-coverage": "~13.0|~14.0"
     },
@@ -35,6 +34,10 @@
     "require-dev": {
         "innmind/static-analysis": "~1.3",
         "ramsey/uuid": "^4.1",
-        "innmind/coding-standard": "~2.0"
+        "innmind/coding-standard": "~2.0",
+        "phpunit/phpunit": "~13.0"
+    },
+    "conflict": {
+        "phpunit/phpunit": "<13.0|~14.0"
     }
 }

--- a/src/PHPUnit/Load.php
+++ b/src/PHPUnit/Load.php
@@ -9,10 +9,6 @@ use Innmind\BlackBox\{
     PHPUnit\Framework\Attributes\Group,
     Tag,
 };
-use PHPUnit\Framework\Attributes\{
-    DataProvider as PHPUnitDataProvider,
-    Group as PHPUnitGroup,
-};
 
 final class Load
 {
@@ -61,16 +57,10 @@ final class Load
                     continue;
                 }
 
-                $attributes = \array_merge(
-                    $method->getAttributes(PHPUnitDataProvider::class),
-                    $method->getAttributes(DataProvider::class),
-                );
+                $attributes = $method->getAttributes(DataProvider::class);
                 $groups = \array_map(
                     static fn($group) => $group->newInstance()->name(),
-                    \array_merge(
-                        $method->getAttributes(PHPUnitGroup::class),
-                        $method->getAttributes(Group::class),
-                    ),
+                    $method->getAttributes(Group::class),
                 );
                 $tags = \array_values(\array_filter(
                     \array_map(

--- a/tests/PHPUnit/BlackBoxTest.php
+++ b/tests/PHPUnit/BlackBoxTest.php
@@ -9,7 +9,6 @@ use Innmind\BlackBox\{
     PHPUnit\Framework\Attributes\DataProvider,
     Set,
 };
-use PHPUnit\Framework\Attributes\DataProvider as PHPUnitDataProvider;
 
 class BlackBoxTest extends TestCase
 {
@@ -26,7 +25,6 @@ class BlackBoxTest extends TestCase
     }
 
     #[DataProvider('ints2')]
-    #[PHPUnitDataProvider('ints2')]
     public function testMultipleDataProviders($a, $b)
     {
         $this->assertIsInt($a);


### PR DESCRIPTION
Fix #49

Unlike specified in the issue the PHPUnit compatibility doesn't need to be extracted into its on package. 

When only in a BlackBox mode it now longer needs any PHPUnit code to be able to run PHPUnit tests as all the code is prefixed now.

And the dependency can be optional as is someone does use BlackBox inside PHPUnit then PHPUnit is already required in their project.