### PR TITLE
Fix displaying last successful debug shrunk values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- `$assert->debug()` was leaking the last successful shrunk values
+
 ## 7.0.0 - 2026-05-14
 
 ### Added

--- a/proofs/application.php
+++ b/proofs/application.php
@@ -622,17 +622,15 @@ return static function(Prove $prove) {
                     ->tryToProve(static function(Prove $prove) {
                         yield $prove
                             ->proof('debug')
-                            ->given(Set::integers()->between(0, 100))
+                            ->given(Set::integers()->above(0))
                             ->test(static function(Assert $assert, $i) {
                                 $assert->debug('shrunk', $i);
 
-                                if ($i > 50 || $i === 0) {
-                                    $assert->true(true);
-
-                                    return;
+                                if ($i > 0) {
+                                    $assert->true(false);
                                 }
 
-                                $assert->true(false);
+                                $assert->true(true);
                             });
                     });
 

--- a/proofs/application.php
+++ b/proofs/application.php
@@ -5,8 +5,10 @@ use Innmind\BlackBox\{
     Application,
     Random,
     Set,
+    Runner\Assert,
     Runner\Load,
     Runner\IO\Collect,
+    Prove,
     Tag,
 };
 use Fixtures\Innmind\BlackBox\{
@@ -20,7 +22,7 @@ use Fixtures\Innmind\BlackBox\{
     UpperBoundAtHundred,
 };
 
-return static function($prove) {
+return static function(Prove $prove) {
     yield $prove
         ->proof('BlackBox can run with any of the random strategies')
         ->given(Set::of(...Random::cases()))
@@ -604,6 +606,40 @@ return static function($prove) {
                     ->not()
                     ->contains('$a = 0')
                     ->contains("SF\n\n\$a = 1\n");
+            },
+        )
+        ->tag(Tag::ci, Tag::local);
+
+    yield $prove
+        ->test(
+            '$assert->debug() does not leak the last successful shrunk value',
+            static function($assert) {
+                $io = Collect::new();
+
+                $result = Application::new([])
+                    ->displayVia($io)
+                    ->mapPrinter(static fn($printer) => $printer->withoutColors())
+                    ->tryToProve(static function(Prove $prove) {
+                        yield $prove
+                            ->proof('debug')
+                            ->given(Set::integers()->between(0, 100))
+                            ->test(static function(Assert $assert, $i) {
+                                $assert->debug('shrunk', $i);
+
+                                if ($i > 50 || $i === 0) {
+                                    $assert->true(true);
+
+                                    return;
+                                }
+
+                                $assert->true(false);
+                            });
+                    });
+
+                $assert->false($result->successful());
+                $assert
+                    ->string($io->toString())
+                    ->contains('$shrunk = 1');
             },
         )
         ->tag(Tag::ci, Tag::local);

--- a/src/Runner/Assert/Debug.php
+++ b/src/Runner/Assert/Debug.php
@@ -31,6 +31,16 @@ final class Debug
 
     /**
      * @internal
+     */
+    public function snapshot(): self
+    {
+        $snapshot = new self($this->data);
+
+        return $snapshot;
+    }
+
+    /**
+     * @internal
      *
      * @param non-empty-string $name
      */

--- a/src/Runner/Runner/Strategy.php
+++ b/src/Runner/Runner/Strategy.php
@@ -62,6 +62,7 @@ enum Strategy
     ): void {
         $identity = $this->hash($previousFailure);
         $previousStrategy = $scenario;
+        $previousDebug = $debug;
         $dichotomy = $scenario->shrink();
 
         do {
@@ -69,7 +70,7 @@ enum Strategy
                 throw Scenario\Failure::of(
                     $previousFailure,
                     $previousStrategy,
-                    $debug,
+                    $previousDebug,
                 );
             }
 
@@ -114,6 +115,7 @@ enum Strategy
                 $dichotomy = null;
             } catch (Assert\Failure $e) {
                 $dichotomy = $currentStrategy->shrink();
+                $previousDebug = $debug->snapshot();
                 $previousFailure = $e;
                 $previousStrategy = $currentStrategy;
 


### PR DESCRIPTION
In case the shrinking process finds both strategies (`a` and `b`) to succeed, then the values displayed via `$assert-debug()` are the ones from the successful `b` strategy instead of the ones from the last failing scenario.